### PR TITLE
fix: use empty allocation when no config key is present

### DIFF
--- a/runtime/src/export.rs
+++ b/runtime/src/export.rs
@@ -183,7 +183,7 @@ pub(crate) fn config_get(
     let val = plugin!(data).manifest.as_ref().config.get(str);
     let mem = match val {
         Some(f) => memory!(mut data).alloc_bytes(f.as_bytes())?,
-        None => return Err(Trap::new("Invalid config key")),
+        None => memory!(mut data).alloc_bytes(&[])?,
     };
 
     output[0] = Val::I64(mem.offset as i64);


### PR DESCRIPTION
@zshipko - pretty sure this is not optimal, but idk if there is a path to the same effect without actually calling the alloc routines. 

re: https://github.com/extism/assemblyscript-pdk/pull/4