### PR TITLE
ci: add host sdk releases 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,18 +14,20 @@ jobs:
   release-linux:
     name: linux
     runs-on: ubuntu-latest
-    strategy: 
+    strategy:
       matrix:
-        target: [ 
-          aarch64-unknown-linux-gnu, 
-          aarch64-unknown-linux-musl, 
-          # i686-unknown-linux-gnu, 
-          x86_64-unknown-linux-gnu ]
+        target:
+          [
+            aarch64-unknown-linux-gnu,
+            aarch64-unknown-linux-musl,
+            x86_64-unknown-linux-gnu,
+          ]
+          # i686-unknown-linux-gnu,
     if: always()
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
-      
+        uses: actions/checkout@v3
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -40,7 +42,7 @@ jobs:
           use-cross: true
           command: build
           args: --release --target ${{ matrix.target }} -p ${{ env.RUNTIME_CRATE }}
-  
+
       - name: Prepare Artifact
         run: |
           EXT=so
@@ -49,21 +51,21 @@ jobs:
           RELEASE_NAME=libextism-${{ matrix.target }}-${{ github.ref_name }}
           ARCHIVE=${RELEASE_NAME}.tar.gz
           CHECKSUM=${RELEASE_NAME}.checksum.txt
-          
+
           # compress the shared library & create checksum
           cp runtime/extism.h ${SRC_DIR}
           cp LICENSE ${SRC_DIR}
           tar -C ${SRC_DIR} -czvf ${ARCHIVE} libextism.${EXT} extism.h
           ls -ll ${ARCHIVE}
           shasum -a 256 ${ARCHIVE} > ${CHECKSUM}
-        
+
           # copy archive and checksum into release artifact directory
           mkdir -p ${DEST_DIR}
           cp ${ARCHIVE} ${DEST_DIR}
           cp ${CHECKSUM} ${DEST_DIR}
-  
+
           ls ${DEST_DIR}
-      
+
       - name: Upload Artifact to Summary
         uses: actions/upload-artifact@v3
         with:
@@ -78,20 +80,18 @@ jobs:
           files: |
             *.tar.gz
             *.txt
-  
+
   release-macos:
     name: macos
     runs-on: macos-latest
-    strategy: 
+    strategy:
       matrix:
-        target: [ 
-          x86_64-apple-darwin,
-          aarch64-apple-darwin ]
+        target: [x86_64-apple-darwin, aarch64-apple-darwin]
     if: always()
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
-      
+        uses: actions/checkout@v3
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -115,21 +115,21 @@ jobs:
           RELEASE_NAME=libextism-${{ matrix.target }}-${{ github.ref_name }}
           ARCHIVE=${RELEASE_NAME}.tar.gz
           CHECKSUM=${RELEASE_NAME}.checksum.txt
-          
+
           # compress the shared library & create checksum
           cp runtime/extism.h ${SRC_DIR}
           cp LICENSE ${SRC_DIR}
           tar -C ${SRC_DIR} -czvf ${ARCHIVE} libextism.${EXT} extism.h
           ls -ll ${ARCHIVE}
           shasum -a 256 ${ARCHIVE} > ${CHECKSUM}
-        
+
           # copy archive and checksum into release artifact directory
           mkdir -p ${DEST_DIR}
           cp ${ARCHIVE} ${DEST_DIR}
           cp ${CHECKSUM} ${DEST_DIR}
-  
+
           ls ${DEST_DIR}
-      
+
       - name: Upload Artifact to Summary
         uses: actions/upload-artifact@v3
         with:
@@ -148,20 +148,18 @@ jobs:
   release-windows:
     name: windows
     runs-on: windows-latest
-    strategy: 
+    strategy:
       matrix:
-        target: [ 
+        target:
+          [x86_64-pc-windows-gnu, x86_64-pc-windows-msvc]
           # i686-pc-windows-gnu,
           # i686-pc-windows-msvc,
-          x86_64-pc-windows-gnu,
-          x86_64-pc-windows-msvc,
-          # aarch64-pc-windows-msvc 
-          ]
+          # aarch64-pc-windows-msvc
     if: always()
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
-      
+        uses: actions/checkout@v3
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -173,7 +171,7 @@ jobs:
       - name: Build Target (${{ matrix.target }})
         uses: actions-rs/cargo@v1
         with:
-          use-cross: false
+          use-cross: true
           command: build
           args: --release --target ${{ matrix.target }} -p ${{ env.RUNTIME_CRATE }}
 
@@ -186,22 +184,22 @@ jobs:
           RELEASE_NAME=libextism-${{ matrix.target }}-${{ github.ref_name }}
           ARCHIVE=${RELEASE_NAME}.tar.gz
           CHECKSUM=${RELEASE_NAME}.checksum.txt
-        
+
           # compress the shared library & create checksum
           cp runtime/extism.h ${SRC_DIR}
           cp LICENSE ${SRC_DIR}
           tar -C ${SRC_DIR} -czvf ${ARCHIVE} libextism.${EXT} extism.h
           ls -ll ${ARCHIVE}
-        
+
           certutil -hashfile ${ARCHIVE} SHA256 >${CHECKSUM}
-        
+
           # copy archive and checksum into release artifact directory
           mkdir -p ${DEST_DIR}
           cp ${ARCHIVE} ${DEST_DIR}
           cp ${CHECKSUM} ${DEST_DIR}
-  
+
           ls ${DEST_DIR}
-      
+
       - name: Upload Artifact to Summary
         uses: actions/upload-artifact@v3
         with:
@@ -216,3 +214,61 @@ jobs:
           files: |
             *.tar.gz
             *.txt
+
+  release-sdks:
+    needs: [release-linux, release-macos] # release-windows
+    name: publish-sdks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node env
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Release Node Host SDK
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_API_TOKEN }}
+          CI: true
+        run: |
+          cd node
+          npm publish
+
+      - name: Setup Rust env
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+
+      - name: Release Rust Host SDK
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_API_TOKEN }}
+        run: |
+          # order of crate publication matter: manifest, runtime, rust
+          cargo publish --manifest-path manifest/Cargo.toml
+          cargo publish --manifest-path runtime/Cargo.toml
+          cargo publish --manifest-path rust/Cargo.toml
+
+      - name: Setup Python env
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          check-latest: true
+
+      - name: Build Python Host SDK
+        run: |
+          pushd python
+          python3 -m pip install --upgrade build
+          python3 -m build
+          popd
+
+      - name: Release Python Host SDK
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.PYPI_API_USER }}
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: python/dist/

--- a/manifest/Cargo.toml
+++ b/manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extism-manifest"
-version = "0.0.1-alpha"
+version = "0.0.1-rc.2"
 edition = "2021"
 authors = ["The Extism Authors", "oss@extism.org"]
 license = "BSD-3-Clause"

--- a/node/example.js
+++ b/node/example.js
@@ -3,5 +3,11 @@ import { readFileSync } from "fs";
 
 let wasm = readFileSync("../wasm/code.wasm");
 let p = new Plugin(wasm);
+
+if (!p.function_exists("count_vowels")) {
+    console.log("no function 'count_vowels' in wasm");
+    process.exit(1);
+}
+
 let buf = p.call("count_vowels", process.argv[2] || "this is a test");
 console.log(JSON.parse(buf.toString())['count']);

--- a/node/index.js
+++ b/node/index.js
@@ -12,7 +12,7 @@ let _functions = {
   extism_output_length: ['uint64', ['int32']],
   extism_output_get: ['uint8*', ['int32']],
   extism_log_file: ['bool', ['string', 'char*']],
-  extism_function_exists: ['bool', ['string']],
+  extism_function_exists: ['bool', ['int32', 'string']],
   extism_plugin_config: ['void', ['int32', 'char*', 'uint64']],
 };
 

--- a/node/index.js
+++ b/node/index.js
@@ -79,7 +79,7 @@ export class Plugin {
   }
 
   function_exists(name) {
-    return lib.extism_function_exists(name)
+    return lib.extism_function_exists(this.id, name)
   }
 
   call(name, input) {

--- a/node/index.js
+++ b/node/index.js
@@ -12,6 +12,7 @@ let _functions = {
   extism_output_length: ['uint64', ['int32']],
   extism_output_get: ['uint8*', ['int32']],
   extism_log_file: ['bool', ['string', 'char*']],
+  extism_function_exists: ['bool', ['string']],
   extism_plugin_config: ['void', ['int32', 'char*', 'uint64']],
 };
 
@@ -27,7 +28,6 @@ function locate(paths) {
     }
   }
 
-
   throw "Unable to locate libextism";
 }
 
@@ -39,6 +39,7 @@ if (process.env.EXTISM_PATH) {
 }
 
 var lib = locate(searchPath);
+
 export function set_log_file(filename, level = null) {
   lib.extism_log_file(filename, level)
 }
@@ -77,14 +78,18 @@ export class Plugin {
     return true;
   }
 
+  function_exists(name) {
+    return lib.extism_function_exists(name)
+  }
+
   call(name, input) {
     var rc = lib.extism_call(this.id, name, input, input.length);
     if (rc != 0) {
       var err = lib.extism_error(this.id);
       if (err.length == 0) {
-        throw "extism_call failed";
+        throw `extism_call: "${name}" failed`;
       }
-      throw err.toString();
+      throw `Plugin error: ${err.toString()}, code: ${rc}`;
     }
 
     var out_len = lib.extism_output_length(this.id);

--- a/node/package.json
+++ b/node/package.json
@@ -1,15 +1,26 @@
 {
-  "name": "node",
-  "version": "1.0.0",
-  "description": "",
+  "name": "@extism/extism",
+  "version": "0.0.1-rc.2",
+  "description": "Extism Host SDK for Node",
+  "keywords": [
+    "extism",
+    "webassembly",
+    "wasm",
+    "plugins",
+    "extension"
+  ],
+  "author": "The Extism Authors <oss@extism.org>",
+  "license": "BSD-3-Clause",
   "main": "index.js",
   "type": "module",
-  "scripts": {
-    "example": "node example.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "homepage": "https://extism.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/extism/extism.git"
   },
-  "author": "",
-  "license": "ISC",
+  "scripts": {
+    "example": "node example.js"
+  },
   "dependencies": {
     "ffi-napi": "^4.0.3"
   }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "extism"
-version = "0.0.1-rc.1"
+version = "0.0.1-rc.2"
 description = ""
 authors = ["The Extism Authors <oss@extism.org>"]
 license = "BSD-3-Clause"

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,0 +1,12 @@
+[metadata]
+name = extism
+description = Extism Host SDK for Rust
+long_description_content_type = text/markdown
+url = https://github.com/extism/extism
+project_urls =
+    Bug Tracker = https://github.com/extism/extism/issues
+    Changelog = https://github.com/extism/extism/releases
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: BSD License
+    Intended Audience :: Developers

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extism-runtime"
-version = "0.0.1-alpha"
+version = "0.0.1-rc.2"
 edition = "2021"
 authors = ["The Extism Authors", "oss@extism.org"]
 license = "BSD-3-Clause"
@@ -25,7 +25,7 @@ sha2 = "0.10"
 log = "0.4"
 log4rs = "1.1"
 ureq = {version = "2.5", optional=true}
-extism-manifest = { version = "0.0.1-alpha", path = "../manifest" }
+extism-manifest = { version = "0.0.1-rc.2", path = "../manifest" }
 pretty-hex = { version = "0.3" }
 
 [features]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extism"
-version = "0.0.1-alpha"
+version = "0.0.1-rc.2"
 edition = "2021"
 authors = ["The Extism Authors", "oss@extism.org"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
Adds automated releases for crates.io, pypi, and npm for Rust, Python, and Node host SDKs respectively. 