### PR TITLE
Add `allowed_hosts` configuration option

### DIFF
--- a/extism.go
+++ b/extism.go
@@ -67,7 +67,8 @@ type Manifest struct {
 	Memory struct {
 		Max uint32 `json:"max,omitempty"`
 	} `json:"memory,omitempty"`
-	Config map[string]string `json:"config,omitempty"`
+	Config       map[string]string `json:"config,omitempty"`
+	AllowedHosts []string          `json:"allowed_hosts,omitempty"`
 }
 
 func makePointer(data []byte) unsafe.Pointer {

--- a/manifest/schema.json
+++ b/manifest/schema.json
@@ -4,8 +4,11 @@
   "type": "object",
   "properties": {
     "allowed_hosts": {
-      "default": [],
-      "type": "array",
+      "default": null,
+      "type": [
+        "array",
+        "null"
+      ],
       "items": {
         "type": "string"
       }

--- a/manifest/schema.json
+++ b/manifest/schema.json
@@ -3,6 +3,13 @@
   "title": "Manifest",
   "type": "object",
   "properties": {
+    "allowed_hosts": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "config": {
       "default": {},
       "type": "object",

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -76,6 +76,8 @@ pub struct Manifest {
     pub memory: ManifestMemory,
     #[serde(default)]
     pub config: BTreeMap<String, String>,
+    #[serde(default)]
+    pub allowed_hosts: Vec<String>,
 }
 
 mod base64 {

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -77,7 +77,7 @@ pub struct Manifest {
     #[serde(default)]
     pub config: BTreeMap<String, String>,
     #[serde(default)]
-    pub allowed_hosts: Vec<String>,
+    pub allowed_hosts: Option<Vec<String>>,
 }
 
 mod base64 {

--- a/ocaml/lib/extism.ml
+++ b/ocaml/lib/extism.ml
@@ -144,13 +144,14 @@ module Manifest = struct
     wasm : wasm list;
     memory : memory option; [@yojson.option]
     config : config option; [@yojson.option]
+    allowed_hosts: string list option; [@yojson.option]
   }
   [@@deriving yojson]
 
   let file ?name ?hash path = File { path; name; hash }
   let data ?name ?hash data = Data { data; name; hash }
   let url ?header ?name ?meth ?hash url = Url { header; name; meth; hash; url }
-  let v ?config ?memory wasm = { config; wasm; memory }
+  let v ?config ?memory ?allowed_hosts wasm = { config; wasm; memory; allowed_hosts }
   let json t = yojson_of_t t |> Yojson.Safe.to_string
 end
 

--- a/ocaml/lib/extism.mli
+++ b/ocaml/lib/extism.mli
@@ -24,25 +24,30 @@ module Manifest : sig
   }
 
   type wasm = File of wasm_file | Data of wasm_data | Url of wasm_url
-  
+
   type config = (string * string) list
 
   type t = {
     wasm : wasm list;
     memory : memory option;
     config: config option;
+    allowed_hosts: string list option;
   }
 
   val file: ?name:string -> ?hash:string -> string -> wasm
   val data: ?name:string -> ?hash:string -> string -> wasm
   val url: ?header:(string * string) list -> ?name:string -> ?meth:string -> ?hash:string -> string -> wasm
-  val v: ?config:config -> ?memory:memory -> wasm list -> t
+  val v:
+    ?config:config ->
+    ?memory:memory ->
+    ?allowed_hosts: string list ->
+    wasm list -> t
   val json: t -> string
 end
 
 module Context : sig
   type t
-  
+
   val create: unit -> t
   val free: t -> unit
   val reset: t -> unit

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1"
 sha2 = "0.10"
 log = "0.4"
 log4rs = "1.1"
+url = "2.3"
 ureq = {version = "2.5", optional=true}
 extism-manifest = { version = "0.0.1-rc.3", path = "../manifest" }
 pretty-hex = { version = "0.3" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -25,6 +25,7 @@ sha2 = "0.10"
 log = "0.4"
 log4rs = "1.1"
 url = "2.3"
+glob = "0.3"
 ureq = {version = "2.5", optional=true}
 extism-manifest = { version = "0.0.1-rc.3", path = "../manifest" }
 pretty-hex = { version = "0.3" }

--- a/runtime/src/export.rs
+++ b/runtime/src/export.rs
@@ -379,8 +379,16 @@ pub(crate) fn http_request(
             Err(e) => return Err(Trap::new(format!("Invalid URL: {e:?}"))),
         };
         let allowed_hosts = &data.plugin().manifest.as_ref().allowed_hosts;
-        let host_str = url.host_str().unwrap_or_default().to_string();
-        if !allowed_hosts.is_empty() && !allowed_hosts.contains(&host_str) {
+        let host_str = url.host_str().unwrap_or_default();
+        let host_matches_allowed = allowed_hosts.iter().any(|url| {
+            let pat = match glob::Pattern::new(url) {
+                Ok(x) => x,
+                Err(_) => return url == host_str,
+            };
+
+            pat.matches(host_str)
+        });
+        if !allowed_hosts.is_empty() && !host_matches_allowed {
             return Err(Trap::new(format!(
                 "HTTP request to {} is not allowed",
                 req.url

--- a/runtime/src/export.rs
+++ b/runtime/src/export.rs
@@ -380,19 +380,21 @@ pub(crate) fn http_request(
         };
         let allowed_hosts = &data.plugin().manifest.as_ref().allowed_hosts;
         let host_str = url.host_str().unwrap_or_default();
-        let host_matches_allowed = allowed_hosts.iter().any(|url| {
-            let pat = match glob::Pattern::new(url) {
-                Ok(x) => x,
-                Err(_) => return url == host_str,
-            };
+        if let Some(allowed_hosts) = allowed_hosts {
+            let host_matches_allowed = allowed_hosts.iter().any(|url| {
+                let pat = match glob::Pattern::new(url) {
+                    Ok(x) => x,
+                    Err(_) => return url == host_str,
+                };
 
-            pat.matches(host_str)
-        });
-        if !allowed_hosts.is_empty() && !host_matches_allowed {
-            return Err(Trap::new(format!(
-                "HTTP request to {} is not allowed",
-                req.url
-            )));
+                pat.matches(host_str)
+            });
+            if !allowed_hosts.is_empty() && !host_matches_allowed {
+                return Err(Trap::new(format!(
+                    "HTTP request to {} is not allowed",
+                    req.url
+                )));
+            }
         }
 
         let mut r = ureq::request(req.method.as_deref().unwrap_or("GET"), &req.url);

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -28,6 +28,7 @@ impl Internal {
         for (k, v) in manifest.as_ref().config.iter() {
             wasi = wasi.env(k, v)?;
         }
+
         Ok(Internal {
             input_length: 0,
             output_offset: 0,


### PR DESCRIPTION
- Adds `allowed_hosts` to the manifest
- If there are any `allowed_hosts` then `extism_http_request` checks to make sure a URL's host is listed before performing the request
 
One thing to note: I have a branch that also adds `allowed_dirs`, but I'm not sure if that's something I want to include. We had kinda talked about not supporting filesystem access, which simplifies everything. The reason I ended up making that branch is when experimenting with `python.wasm` it seemed to require the current directory to be preopened. Since Python plugin support is a long ways off and we can probably hack around the filesystem requirement it's probably best to leave it `allowed_dirs` out until we know if we'll need it.