### PR TITLE
Add `extism_version` to Host SDK and all clients

### DIFF
--- a/extism.go
+++ b/extism.go
@@ -88,6 +88,11 @@ func SetLogFile(filename string, level string) bool {
 	return bool(r)
 }
 
+// ExtismVersion gets the Extism version string
+func ExtismVersion() string {
+	return C.GoString(C.extism_version())
+}
+
 func register(ctx *Context, data []byte, wasi bool) (Plugin, error) {
 	ptr := makePointer(data)
 	plugin := C.extism_plugin_new(

--- a/go/main.go
+++ b/go/main.go
@@ -9,6 +9,9 @@ import (
 )
 
 func main() {
+	version := extism.ExtismVersion()
+	fmt.Println("Extism Version: ", version)
+
 	ctx := extism.NewContext()
 	defer ctx.Free() // this will free the context and all associated plugins
 

--- a/haskell/src/Extism.hs
+++ b/haskell/src/Extism.hs
@@ -29,6 +29,7 @@ foreign import ccall unsafe "extism.h extism_log_file" extism_log_file :: CStrin
 foreign import ccall unsafe "extism.h extism_plugin_config" extism_plugin_config :: Ptr ExtismContext -> Int32 -> Ptr Word8 -> Int64 -> IO CBool
 foreign import ccall unsafe "extism.h extism_plugin_free" extism_plugin_free :: Ptr ExtismContext -> Int32 -> IO ()
 foreign import ccall unsafe "extism.h extism_context_reset" extism_context_reset :: Ptr ExtismContext -> IO ()
+foreign import ccall unsafe "extism.h extism_version" extism_version :: IO CString
 
 -- Context manages plugins
 newtype Context = Context (ForeignPtr ExtismContext)
@@ -46,6 +47,11 @@ toByteString x = B.pack (Prelude.map c2w x)
 -- Helper function to convert a bytestring to a string
 fromByteString :: ByteString -> String
 fromByteString bs = Prelude.map w2c $ B.unpack bs
+
+-- Get the Extism version string
+extismVersion :: () -> IO String
+extismVersion () =
+  peekCString extism_version
 
 -- Remove all registered plugins in a Context
 reset :: Context -> IO ()

--- a/haskell/src/Extism.hs
+++ b/haskell/src/Extism.hs
@@ -52,7 +52,7 @@ fromByteString bs = Prelude.map w2c $ B.unpack bs
 extismVersion :: () -> IO String
 extismVersion () = do
   v <- extism_version
-  return (peekCString v)
+  peekCString v
 
 -- Remove all registered plugins in a Context
 reset :: Context -> IO ()

--- a/haskell/src/Extism.hs
+++ b/haskell/src/Extism.hs
@@ -29,7 +29,7 @@ foreign import ccall unsafe "extism.h extism_log_file" extism_log_file :: CStrin
 foreign import ccall unsafe "extism.h extism_plugin_config" extism_plugin_config :: Ptr ExtismContext -> Int32 -> Ptr Word8 -> Int64 -> IO CBool
 foreign import ccall unsafe "extism.h extism_plugin_free" extism_plugin_free :: Ptr ExtismContext -> Int32 -> IO ()
 foreign import ccall unsafe "extism.h extism_context_reset" extism_context_reset :: Ptr ExtismContext -> IO ()
-foreign import ccall unsafe "extism.h extism_version" extism_version :: IO (CString)
+foreign import ccall unsafe "extism.h extism_version" extism_version :: IO CString
 
 -- Context manages plugins
 newtype Context = Context (ForeignPtr ExtismContext)
@@ -50,8 +50,9 @@ fromByteString bs = Prelude.map w2c $ B.unpack bs
 
 -- Get the Extism version string
 extismVersion :: () -> IO String
-extismVersion () =
-  peekCString extism_version
+extismVersion () = do
+  v <- extism_version
+  return (peekCString v)
 
 -- Remove all registered plugins in a Context
 reset :: Context -> IO ()

--- a/haskell/src/Extism.hs
+++ b/haskell/src/Extism.hs
@@ -29,7 +29,7 @@ foreign import ccall unsafe "extism.h extism_log_file" extism_log_file :: CStrin
 foreign import ccall unsafe "extism.h extism_plugin_config" extism_plugin_config :: Ptr ExtismContext -> Int32 -> Ptr Word8 -> Int64 -> IO CBool
 foreign import ccall unsafe "extism.h extism_plugin_free" extism_plugin_free :: Ptr ExtismContext -> Int32 -> IO ()
 foreign import ccall unsafe "extism.h extism_context_reset" extism_context_reset :: Ptr ExtismContext -> IO ()
-foreign import ccall unsafe "extism.h extism_version" extism_version :: IO CString
+foreign import ccall unsafe "extism.h extism_version" extism_version :: IO (CString)
 
 -- Context manages plugins
 newtype Context = Context (ForeignPtr ExtismContext)

--- a/node/index.js
+++ b/node/index.js
@@ -18,6 +18,7 @@ let _functions = {
   extism_plugin_config: ['void', [context, 'int32', 'char*', 'uint64']],
   extism_plugin_free: ['void', [context, 'int32']],
   extism_context_reset: ['void', [context]],
+  extism_version: ['char*', []],
 };
 
 function locate(paths) {
@@ -48,6 +49,11 @@ var lib = locate(searchPath);
 // Set the log file and level
 export function setLogFile(filename, level = null) {
   lib.extism_log_file(filename, level);
+}
+
+// Get the version of Extism
+export function extismVersion() {
+  return lib.extism_version().toString();
 }
 
 const pluginRegistry = new FinalizationRegistry(({ id, pointer }) => {

--- a/ocaml/lib/extism.ml
+++ b/ocaml/lib/extism.ml
@@ -77,6 +77,9 @@ module Bindings = struct
   let extism_log_file =
     fn "extism_log_file" (string @-> string_opt @-> returning bool)
 
+  let extism_version =
+    fn "extism_version" (void @-> returning string)
+
   let extism_plugin_free =
     fn "extism_plugin_free" (context @-> int32_t @-> returning void)
 
@@ -267,3 +270,5 @@ let function_exists { id; ctx } name =
   Bindings.extism_plugin_function_exists ctx.pointer id name
 
 let set_log_file ?level filename = Bindings.extism_log_file filename level
+
+let extism_version = Bindings.extism_version

--- a/php/src/Context.php
+++ b/php/src/Context.php
@@ -51,3 +51,11 @@ function set_log_file($filename, $level)
     
     $lib->extism_log_file($filename, $level);
 }
+
+function extism_version()
+{
+    global $lib;
+
+    return $lib->extism_version();
+}
+

--- a/php/src/extism.h
+++ b/php/src/extism.h
@@ -32,3 +32,5 @@ ExtismSize extism_output_length(ExtismPlugin plugin);
 void extism_output_get(ExtismPlugin plugin, uint8_t *buf, ExtismSize len);
 
 bool extism_log_file(const char *filename, const char *log_level);
+
+const char *extism_version();

--- a/python/extism/__init__.py
+++ b/python/extism/__init__.py
@@ -1,1 +1,1 @@
-from .extism import Error, Plugin, set_log_file, Context
+from .extism import Error, Plugin, set_log_file, Context, extism_version

--- a/python/extism/extism.py
+++ b/python/extism/extism.py
@@ -93,6 +93,9 @@ def set_log_file(file, level=ffi.NULL):
         level = level.encode()
     lib.extism_log_file(file.encode(), level)
 
+def extism_version():
+    '''Gets the Extism version string'''
+    return ffi.string(lib.extism_version()).decode()
 
 def _wasm(plugin):
     if isinstance(plugin, str) and os.path.exists(plugin):

--- a/ruby/lib/extism.rb
+++ b/ruby/lib/extism.rb
@@ -17,10 +17,16 @@ module Extism
     attach_function :extism_log_file, [:string, :pointer], :void
     attach_function :extism_plugin_free, [:pointer, :int32], :void
     attach_function :extism_context_reset, [:pointer], :void
+    attach_function :extism_version, [], :string
   end
 
 
   class Error < StandardError
+  end
+
+  # Return the version of Extism
+  def self.extism_version
+    C.extism_version
   end
 
   # Set log file and level, this is a global configuration

--- a/runtime/extism.h
+++ b/runtime/extism.h
@@ -107,4 +107,7 @@ const uint8_t *extism_plugin_output_data(struct ExtismContext *ctx, ExtismPlugin
  */
 bool extism_log_file(const char *filename, const char *log_level);
 
-const uint8_t *extism_version(void);
+/**
+ * Get the Extism version string
+ */
+const char *extism_version(void);

--- a/runtime/extism.h
+++ b/runtime/extism.h
@@ -107,4 +107,7 @@ const uint8_t *extism_plugin_output_data(struct ExtismContext *ctx, ExtismPlugin
  */
 bool extism_log_file(const char *filename, const char *log_level);
 
+/**
+ * Get the Extism version string
+ */
 const char *extism_version(void);

--- a/runtime/extism.h
+++ b/runtime/extism.h
@@ -106,3 +106,5 @@ const uint8_t *extism_plugin_output_data(struct ExtismContext *ctx, ExtismPlugin
  * Set log file and level
  */
 bool extism_log_file(const char *filename, const char *log_level);
+
+const uint8_t *extism_version(void);

--- a/runtime/extism.h
+++ b/runtime/extism.h
@@ -107,7 +107,4 @@ const uint8_t *extism_plugin_output_data(struct ExtismContext *ctx, ExtismPlugin
  */
 bool extism_log_file(const char *filename, const char *log_level);
 
-/**
- * Get the Extism version string
- */
 const char *extism_version(void);

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -386,7 +386,8 @@ pub unsafe extern "C" fn extism_log_file(
     true
 }
 
+// Get the Extism version string
 #[no_mangle]
-pub unsafe extern "C" fn extism_version() -> *const u8 {
-    env!("CARGO_PKG_VERSION").as_ptr()
+pub unsafe extern "C" fn extism_version() -> *const c_char {
+    env!("CARGO_PKG_VERSION").as_ptr() as *const _
 }

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -383,5 +383,11 @@ pub unsafe extern "C" fn extism_log_file(
     if log4rs::init_config(config).is_err() {
         return false;
     }
+
     true
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn extism_version() -> *const u8 {
+    env!("CARGO_PKG_VERSION").as_ptr()
 }

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -383,7 +383,6 @@ pub unsafe extern "C" fn extism_log_file(
     if log4rs::init_config(config).is_err() {
         return false;
     }
-
     true
 }
 

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -386,7 +386,7 @@ pub unsafe extern "C" fn extism_log_file(
     true
 }
 
-// Get the Extism version string
+/// Get the Extism version string
 #[no_mangle]
 pub unsafe extern "C" fn extism_version() -> *const c_char {
     env!("CARGO_PKG_VERSION").as_ptr() as *const _

--- a/rust/src/bindings.rs
+++ b/rust/src/bindings.rs
@@ -87,4 +87,3 @@ extern "C" {
     pub fn extism_version(
     ) -> *const ::std::os::raw::c_char;
 }
-

--- a/rust/src/bindings.rs
+++ b/rust/src/bindings.rs
@@ -82,3 +82,9 @@ extern "C" {
         log_level: *const ::std::os::raw::c_char,
     ) -> bool;
 }
+
+extern "C" {
+    pub fn extism_version(
+    ) -> *const ::std::os::raw::c_char;
+}
+

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -24,6 +24,13 @@ impl From<serde_json::Error> for Error {
     }
 }
 
+/// Get's the version of Extism
+pub fn extism_version() -> String {
+    let err = unsafe { bindings::extism_version() };
+    let buf = unsafe { std::ffi::CStr::from_ptr(err) };
+    return buf.to_str().unwrap().to_string();
+}
+
 /// Set the log file and level, this is a global setting
 pub fn set_log_file(filename: impl AsRef<std::path::Path>, log_level: Option<log::Level>) {
     let log_level = log_level.map(|x| x.as_str());

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -24,7 +24,7 @@ impl From<serde_json::Error> for Error {
     }
 }
 
-/// Get's the version of Extism
+/// Gets the version of Extism
 pub fn extism_version() -> String {
     let err = unsafe { bindings::extism_version() };
     let buf = unsafe { std::ffi::CStr::from_ptr(err) };


### PR DESCRIPTION
Adds a new Host SDK call `extism_version` which returns the version string.