### PR TITLE
Fix Elixir cargo dependency

### DIFF
--- a/elixir/native/extism_nif/Cargo.toml
+++ b/elixir/native/extism_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extism_nif"
-version = "0.0.1-rc.3"
+version = "0.0.1-rc.5"
 edition = "2021"
 authors = ["Benjamin Eckel <bhelx@simst.im>"]
 
@@ -11,6 +11,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.26.0"
-extism = { version = "0.0.1-rc.3", path = "../../../rust" }
+extism = { version = "0.0.1-rc.5" }
 log = "0.4"
-


### PR DESCRIPTION
I thought this would look for the local path then fallback to the crates.io version. Ideally we want this to be conditional somehow.