### PR TITLE
ci: create workflow for each language

### DIFF
--- a/.github/actions/extism/action.yml
+++ b/.github/actions/extism/action.yml
@@ -1,0 +1,18 @@
+on: [workflow_call]
+
+name: libextism
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout sources
+      uses: actions/checkout@v3
+    - name: Download libextism
+      uses: actions/download-artifact@v3
+      with:
+        name: libextism-${{ matrix.os }}
+    - name: Install extism shared library
+      shell: bash
+      run: |
+        sudo cp libextism.* /usr/local/lib
+        sudo cp runtime/extism.h /usr/local/include

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,17 @@ jobs:
         with:
           enable-stack: true
           stack-version: "latest"
-
+      - name: Cache Haskell
+        id: cache-haskell
+        uses: actions/cache@v3
+        with:
+          path: .stack-work
+          key: ${{ runner.os }}-haskell-${{ hashFiles('haskell/**') }}
+      - name: Build Haskell Host SDK
+        if: steps.cache-haskell.outputs.cache-hit != 'true'
+        run: |
+          cd haskell
+          LD_LIBRARY_PATH=/usr/local/lib stack build
       - name: Test Haskell SDK
         run: |
           cd haskell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
         run: cargo clippy --release --all-features --no-deps -p ${{ env.RUNTIME_CRATE }}
       - name: Test
         run: cargo test --all-features --release -p ${{ env.RUNTIME_CRATE }}
+
   rust:
     name: Rust
     needs: lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: target/**
-          key: ${{ runner.os }}-libextism-${{ hashFiles('runtime/**') }}-${{ hashFiles('manifest/**') }}
+          key: ${{ runner.os }}-target-${{ env.GITHUB_SHA }}
       - name: Build
         if: steps.cache-libextism.outputs.cache-hit != 'true'
         shell: bash
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: target/**
-          key: ${{ runner.os }}-libextism-${{ hashFiles('runtime/**') }}-${{ hashFiles('manifest/**') }}
+          key: ${{ runner.os }}-target-${{ env.GITHUB_SHA }}
       - name: Format
         run: cargo fmt --check -p ${{ env.RUNTIME_CRATE }}
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,95 @@ env:
   RUST_SDK_CRATE: extism
 
 jobs:
-  build_and_test:
-    name: Build & Test
+  lib:
+    name: Extism runtime lib
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust:
+          - stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache Rust environment
+        uses: Swatinem/rust-cache@v1
+      - name: Cache libextism
+        id: cache-libextism
+        uses: actions/cache@v3
+        with:
+          path: target/release/libextism.*
+          key: ${{ runner.os }}-libextism-${{ hashFiles('runtime/**') }}-${{ hashFiles('manifest/**') }}
+      - name: Cache target
+        id: cache-target
+        uses: actions/cache@v3
+        with:
+          path: target/**
+          key: ${{ runner.os }}-libextism-${{ hashFiles('runtime/**') }}-${{ hashFiles('manifest/**') }}
+      - name: Build
+        if: steps.cache-libextism.outputs.cache-hit != 'true'
+        shell: bash
+        run: cargo build --release -p ${{ env.RUNTIME_CRATE }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: libextism-${{ matrix.os }}
+          path: |
+              target/release/libextism.*
+  lint_and_test:
+    name: Extism runtime lint and test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust:
+          - stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cache Rust environment
+        uses: Swatinem/rust-cache@v1
+      - name: Cache target
+        id: cache-target
+        uses: actions/cache@v3
+        with:
+          path: target/**
+          key: ${{ runner.os }}-libextism-${{ hashFiles('runtime/**') }}-${{ hashFiles('manifest/**') }}
+      - name: Format
+        run: cargo fmt --check -p ${{ env.RUNTIME_CRATE }}
+      - name: Lint
+        run: cargo clippy --release --all-features --no-deps -p ${{ env.RUNTIME_CRATE }}
+      - name: Test
+        run: cargo test --all-features --release -p ${{ env.RUNTIME_CRATE }}
+  rust:
+    name: Rust
+    needs: lib
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust:
+          - stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/extism
+      - name: Test Rust Host SDK
+        run: LD_LIBRARY_PATH=/usr/local/lib cargo test --release -p ${{ env.RUST_SDK_CRATE }}
+
+  elixir:
+    name: Elixir
+    needs: lib
     runs-on: ${{ matrix.os }}
     env:
       MIX_ENV: test
@@ -21,32 +108,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
-
-      - name: Cache Rust environment
-        uses: Swatinem/rust-cache@v1
-
-      - name: Format
-        run: cargo fmt --check -p ${{ env.RUNTIME_CRATE }}
-
-      - name: Build
-        run: cargo build --release -p ${{ env.RUNTIME_CRATE }}
-
-      - name: Lint
-        run: cargo clippy --release --no-deps -p ${{ env.RUNTIME_CRATE }}
-
-      - name: Test
-        run: cargo test --all-features --release -p ${{ env.RUNTIME_CRATE }}
-
-      - name: Install extism shared library
-        shell: bash
-        run: sudo make install
-
+      - uses: ./.github/actions/extism
       - name: Setup Elixir Host SDK
         if: ${{ runner.os != 'macOS' }}
         uses: erlef/setup-beam@v1
@@ -61,6 +123,19 @@ jobs:
          cd elixir
          LD_LIBRARY_PATH=/usr/local/lib mix do deps.get, test
 
+  go:
+    name: Go
+    needs: lib
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust:
+          - stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/extism
       - name: Setup Go env
         uses: actions/setup-go@v3
 
@@ -71,15 +146,26 @@ jobs:
           LD_LIBRARY_PATH=/usr/local/lib go run main.go
           LD_LIBRARY_PATH=/usr/local/lib go test
 
+  python:
+    name: Python
+    needs: lib
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust:
+          - stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/extism
       - name: Setup Python env
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
           check-latest: true
-
       - name: Install Poetry
         uses: snok/install-poetry@v1
-
       - name: Test Python Host SDK
         run: |
           cd python
@@ -87,6 +173,19 @@ jobs:
           poetry run python example.py
           poetry run python -m unittest discover
 
+  ruby:
+    name: Ruby
+    needs: lib
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust:
+          - stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/extism
       - name: Setup Ruby env
         uses: ruby/setup-ruby@v1
         with:
@@ -99,6 +198,19 @@ jobs:
           ruby example.rb
           rake test
 
+  node:
+    name: Node
+    needs: lib
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust:
+          - stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/extism
       - name: Setup Node env
         uses: actions/setup-node@v3
         with:
@@ -112,14 +224,23 @@ jobs:
           LD_LIBRARY_PATH=/usr/local/lib npm run example
           LD_LIBRARY_PATH=/usr/local/lib npm run test
 
-      - name: Test Rust Host SDK
-        run: LD_LIBRARY_PATH=/usr/local/lib cargo test --release -p ${{ env.RUST_SDK_CRATE }}
-
+  ocaml:
+    name: OCaml
+    needs: lib
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust:
+          - stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/extism
       - name: Setup OCaml env
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ocaml-base-compiler.5.0.0~beta1
-
       - name: Test OCaml Host SDK
         run: |
           opam install -y --deps-only .
@@ -127,6 +248,19 @@ jobs:
           LD_LIBRARY_PATH=/usr/local/lib opam exec -- dune exec ./bin/main.exe
           LD_LIBRARY_PATH=/usr/local/lib opam exec -- dune runtest
 
+  haskell:
+    name: Haskell
+    needs: lib
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust:
+          - stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/extism
       - name: Setup Haskell env
         uses: haskell/actions/setup@v2
         with:
@@ -138,6 +272,19 @@ jobs:
           cd haskell
           LD_LIBRARY_PATH=/usr/local/lib stack test
 
+  php:
+    name: PHP
+    needs: lib
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust:
+          - stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/extism
       - name: Setup PHP env
         uses: shivammathur/setup-php@v2
         with:
@@ -153,16 +300,27 @@ jobs:
           composer install
           php index.php
 
+  cpp:
+    name: C++
+    needs: lib
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust:
+          - stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/extism
       - name: Install C++ SDK deps
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
           brew install jsoncpp googletest pkg-config
-
       - name: Install C++ SDK deps
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           sudo apt-get install g++ libjsoncpp-dev libgtest-dev pkg-config
-
       - name: Run C++ tests
         run: |
           cd cpp
@@ -175,18 +333,15 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-
       - name: Setup Python env
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
           check-latest: true
-
       - name: Install dependencies
         run: |
           sudo apt-get install ripgrep
           pip3 install pycparser
-
       - name: Run coverage script
         id: coverage
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [pull_request, workflow_dispatch]
 
 name: CI
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,9 +241,20 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ocaml-base-compiler.5.0.0~beta1
-      - name: Test OCaml Host SDK
+      - name: Cache OCaml
+        id: cache-ocaml
+        uses: actions/cache@v3
+        with:
+          path: _build
+          key: ${{ runner.os }}-ocaml-${{ hashFiles('ocaml/**') }}-${{ hashFiles('dune-project') }}
+      - name: Build OCaml Host SDK
+        if: steps.cache-ocaml.outputs.cache-hit != 'true'
         run: |
           opam install -y --deps-only .
+          cd ocaml
+          LD_LIBRARY_PATH=/usr/local/lib opam exec -- dune build
+      - name: Test OCaml Host SDK
+        run: |
           cd ocaml
           LD_LIBRARY_PATH=/usr/local/lib opam exec -- dune exec ./bin/main.exe
           LD_LIBRARY_PATH=/usr/local/lib opam exec -- dune runtest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,11 +250,11 @@ jobs:
       - name: Build OCaml Host SDK
         if: steps.cache-ocaml.outputs.cache-hit != 'true'
         run: |
-          opam install -y --deps-only .
           cd ocaml
           LD_LIBRARY_PATH=/usr/local/lib opam exec -- dune build
       - name: Test OCaml Host SDK
         run: |
+          opam install -y --deps-only .
           cd ocaml
           LD_LIBRARY_PATH=/usr/local/lib opam exec -- dune exec ./bin/main.exe
           LD_LIBRARY_PATH=/usr/local/lib opam exec -- dune runtest


### PR DESCRIPTION
Creates a new workflow for each language, allowing all languages to run tests even when one fails

Also disables running on `push` (but once this is merged the workflow can be manually triggered)