### PR TITLE
feat: add `extism_http_status_code` to get the status code of the last HTTP request + fixes for clippy

### DIFF
--- a/runtime/src/context.rs
+++ b/runtime/src/context.rs
@@ -78,8 +78,7 @@ impl Context {
                 return -1;
             }
         };
-        let id = self.insert(plugin);
-        id
+        self.insert(plugin)
     }
 
     /// Set the context error

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -43,6 +43,7 @@ impl Internal {
             let nn = wasmtime_wasi_nn::WasiNnCtx::new()?;
 
             #[cfg(not(feature = "nn"))]
+            #[allow(clippy::let_unit_value)]
             let nn = ();
 
             Some(Wasi {

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -20,6 +20,7 @@ pub struct Internal {
     pub output_length: usize,
     pub plugin: *mut Plugin,
     pub wasi: Option<Wasi>,
+    pub http_status: u16,
 }
 
 pub struct Wasi {
@@ -59,6 +60,7 @@ impl Internal {
             input: std::ptr::null(),
             wasi,
             plugin: std::ptr::null_mut(),
+            http_status: 0,
         })
     }
 
@@ -149,6 +151,7 @@ impl Plugin {
                         var_get(I64) -> I64;
                         var_set(I64, I64);
                         http_request(I64, I64) -> I64;
+                        http_status_code() -> I32;
                         length(I64) -> I64;
                         log_warn(I64);
                         log_info(I64);

--- a/rust/src/context.rs
+++ b/rust/src/context.rs
@@ -21,7 +21,7 @@ impl Context {
         unsafe { bindings::extism_context_reset(&mut *self.lock()) }
     }
 
-    pub(crate) fn lock<'a>(&'a self) -> std::sync::MutexGuard<'a, extism_runtime::Context> {
+    pub(crate) fn lock(&self) -> std::sync::MutexGuard<extism_runtime::Context> {
         match self.0.lock() {
             Ok(x) => x,
             Err(x) => x.into_inner(),

--- a/rust/src/plugin.rs
+++ b/rust/src/plugin.rs
@@ -7,6 +7,10 @@ pub struct Plugin<'a> {
 }
 
 impl<'a> Plugin<'a> {
+    /// Create plugin from a known-good ID
+    ///
+    /// # Safety
+    /// This function does not check to ensure the provided ID is valid
     pub unsafe fn from_id(id: i32, context: &'a Context) -> Plugin<'a> {
         Plugin { id, context }
     }


### PR DESCRIPTION
This is kind of hacky but until we have an established way of encoding complex types in memory it seems good enough