### PR TITLE
fix(node-sdk): Properly calculate length of utf-8 inputs

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -94,6 +94,12 @@ if (process.env.EXTISM_PATH) {
 
 const lib = locate(searchPath);
 
+// get the true byte size of a utf-8 string
+const byteSize = (data: string | Buffer) => {
+  if (Buffer.isBuffer(data)) return data.length;
+  return new Blob([data]).size;
+}
+
 /**
  * Sets the logfile and level of the Extism runtime
  *
@@ -299,7 +305,7 @@ export class Plugin {
     let plugin = lib.extism_plugin_new(
       ctx.pointer,
       dataRaw,
-      dataRaw.length,
+      byteSize(dataRaw),
       wasi
     );
     if (plugin < 0) {
@@ -319,7 +325,7 @@ export class Plugin {
 
     if (config != null) {
       let s = JSON.stringify(config);
-      lib.extism_plugin_config(ctx.pointer, this.id, s, s.length);
+      lib.extism_plugin_config(ctx.pointer, this.id, s, byteSize(s));
     }
   }
 
@@ -344,7 +350,7 @@ export class Plugin {
       this.ctx.pointer,
       this.id,
       dataRaw,
-      dataRaw.length,
+      byteSize(dataRaw),
       wasi
     );
     if (!ok) {
@@ -357,7 +363,7 @@ export class Plugin {
 
     if (config != null) {
       let s = JSON.stringify(config);
-      lib.extism_plugin_config(this.ctx.pointer, this.id, s, s.length);
+      lib.extism_plugin_config(this.ctx.pointer, this.id, s, byteSize(s));
     }
   }
 
@@ -401,7 +407,7 @@ export class Plugin {
         this.id,
         functionName,
         input.toString(),
-        input.length
+        byteSize(input)
       );
       if (rc !== 0) {
         var err = lib.extism_error(this.ctx.pointer, this.id);

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -94,12 +94,6 @@ if (process.env.EXTISM_PATH) {
 
 const lib = locate(searchPath);
 
-// get the true byte size of a utf-8 string
-const byteSize = (data: string | Buffer) => {
-  if (Buffer.isBuffer(data)) return data.length;
-  return new Blob([data]).size;
-}
-
 /**
  * Sets the logfile and level of the Extism runtime
  *
@@ -305,7 +299,7 @@ export class Plugin {
     let plugin = lib.extism_plugin_new(
       ctx.pointer,
       dataRaw,
-      byteSize(dataRaw),
+      Buffer.byteLength(dataRaw, 'utf-8'),
       wasi
     );
     if (plugin < 0) {
@@ -325,7 +319,7 @@ export class Plugin {
 
     if (config != null) {
       let s = JSON.stringify(config);
-      lib.extism_plugin_config(ctx.pointer, this.id, s, byteSize(s));
+      lib.extism_plugin_config(ctx.pointer, this.id, s, Buffer.byteLength(s, 'utf-8'),);
     }
   }
 
@@ -350,7 +344,7 @@ export class Plugin {
       this.ctx.pointer,
       this.id,
       dataRaw,
-      byteSize(dataRaw),
+      Buffer.byteLength(dataRaw, 'utf-8'),
       wasi
     );
     if (!ok) {
@@ -363,7 +357,7 @@ export class Plugin {
 
     if (config != null) {
       let s = JSON.stringify(config);
-      lib.extism_plugin_config(this.ctx.pointer, this.id, s, byteSize(s));
+      lib.extism_plugin_config(this.ctx.pointer, this.id, s, Buffer.byteLength(s, 'utf-8'),);
     }
   }
 
@@ -407,7 +401,7 @@ export class Plugin {
         this.id,
         functionName,
         input.toString(),
-        byteSize(input)
+        Buffer.byteLength(input, 'utf-8'),
       );
       if (rc !== 0) {
         var err = lib.extism_error(this.ctx.pointer, this.id);

--- a/node/tests/index.test.ts
+++ b/node/tests/index.test.ts
@@ -31,6 +31,9 @@ describe("test extism", () => {
       output = await plugin.call("count_vowels", "this is a test thrice");
       result = JSON.parse(output.toString());
       expect(result["count"]).toBe(6);
+      output = await plugin.call("count_vowels", "hello 🌎 world");
+      result = JSON.parse(output.toString());
+      expect(result["count"]).toBe(3);
     });
   });
 

--- a/node/tests/index.test.ts
+++ b/node/tests/index.test.ts
@@ -31,7 +31,7 @@ describe("test extism", () => {
       output = await plugin.call("count_vowels", "this is a test thrice");
       result = JSON.parse(output.toString());
       expect(result["count"]).toBe(6);
-      output = await plugin.call("count_vowels", "hello 🌎 world");
+      output = await plugin.call("count_vowels", "🌎hello🌎world🌎");
       result = JSON.parse(output.toString());
       expect(result["count"]).toBe(3);
     });


### PR DESCRIPTION
Properly calculate the length of utf-8 inputs. I'll work on getting unicode chars into our other tests as well and see if we need to fix any other SDKs