### PR TITLE
test: Make sure we have unicode in the SDK tests

### DIFF
--- a/elixir/test/extism_test.exs
+++ b/elixir/test/extism_test.exs
@@ -35,6 +35,8 @@ defmodule ExtismTest do
     assert JSON.decode(output) == {:ok, %{"count" => 7}}
     {:ok, output} = Extism.Plugin.call(plugin, "count_vowels", "this is a test thrice")
     assert JSON.decode(output) == {:ok, %{"count" => 6}}
+    {:ok, output} = Extism.Plugin.call(plugin, "count_vowels", "🌎hello🌎world🌎")
+    assert JSON.decode(output) == {:ok, %{"count" => 3}}
     Extism.Context.free(ctx)
   end
 

--- a/python/tests/test_extism.py
+++ b/python/tests/test_extism.py
@@ -20,6 +20,8 @@ class TestExtism(unittest.TestCase):
             self.assertEqual(j["count"], 7)
             j = json.loads(plugin.call("count_vowels", "this is a test thrice"))
             self.assertEqual(j["count"], 6)
+            j = json.loads(plugin.call("count_vowels", "🌎hello🌎world🌎"))
+            self.assertEqual(j["count"], 3)
 
     def test_update_plugin_manifest(self):
         with extism.Context() as ctx:

--- a/ruby/test/test_extism.rb
+++ b/ruby/test/test_extism.rb
@@ -20,6 +20,8 @@ class TestExtism < Minitest::Test
       assert_equal res["count"], 7
       res = JSON.parse(plugin.call("count_vowels", "this is a test thrice"))
       assert_equal res["count"], 6
+      res = JSON.parse(plugin.call("count_vowels", "🌎hello🌎world🌎"))
+      assert_equal res["count"], 3
     end
   end
 


### PR DESCRIPTION
Related to https://github.com/extism/extism/pull/82

Ensures we have unicode inputs in our SDK tests. We should probably get unicode in the output as well