### PR TITLE
Updates for wasmtime/wasmtime-wasi/wasmtime-wasi-nn, basic support for calling `_start` functions

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/extism/extism"
 description = "Extism runtime component"
 
 [dependencies]
-wasmtime = "2.0.1"
-wasmtime-wasi = "2.0.1"
-wasmtime-wasi-nn = {version = "2.0.1", optional=true}
+wasmtime = "3.0.0"
+wasmtime-wasi = "3.0.0"
+wasmtime-wasi-nn = {version = "3.0.0", optional=true}
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -7,7 +7,7 @@ macro_rules! args {
     ($input:expr, $index:expr, $ty:ident) => {
         match $input[$index].$ty() {
             Some(x) => x,
-            None => return Err(Trap::new("Invalid input type"))
+            None => return Err(Error::msg("Invalid input type"))
         }
     };
     ($input:expr, $(($index:expr, $ty:ident)),*$(,)?) => {
@@ -24,7 +24,7 @@ pub(crate) fn input_length(
     caller: Caller<Internal>,
     _input: &[Val],
     output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &Internal = caller.data();
     output[0] = Val::I64(data.input_length as i64);
     Ok(())
@@ -37,7 +37,7 @@ pub(crate) fn input_load_u8(
     caller: Caller<Internal>,
     input: &[Val],
     output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &Internal = caller.data();
     if data.input.is_null() {
         return Ok(());
@@ -53,7 +53,7 @@ pub(crate) fn input_load_u64(
     caller: Caller<Internal>,
     input: &[Val],
     output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &Internal = caller.data();
     if data.input.is_null() {
         return Ok(());
@@ -72,12 +72,10 @@ pub(crate) fn store_u8(
     mut caller: Caller<Internal>,
     input: &[Val],
     _output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &mut Internal = caller.data_mut();
     let (offset, byte) = args!(input, (0, i64), (1, i32));
-    data.memory_mut()
-        .store_u8(offset as usize, byte as u8)
-        .map_err(|_| Trap::new("Write error"))?;
+    data.memory_mut().store_u8(offset as usize, byte as u8)?;
     Ok(())
 }
 
@@ -88,13 +86,10 @@ pub(crate) fn load_u8(
     caller: Caller<Internal>,
     input: &[Val],
     output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &Internal = caller.data();
     let offset = args!(input, 0, i64) as usize;
-    let byte = data
-        .memory()
-        .load_u8(offset)
-        .map_err(|_| Trap::new("Read error"))?;
+    let byte = data.memory().load_u8(offset)?;
     output[0] = Val::I32(byte as i32);
     Ok(())
 }
@@ -106,12 +101,10 @@ pub(crate) fn store_u64(
     mut caller: Caller<Internal>,
     input: &[Val],
     _output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &mut Internal = caller.data_mut();
     let (offset, b) = args!(input, (0, i64), (1, i64));
-    data.memory_mut()
-        .store_u64(offset as usize, b as u64)
-        .map_err(|_| Trap::new("Write error"))?;
+    data.memory_mut().store_u64(offset as usize, b as u64)?;
     Ok(())
 }
 
@@ -122,13 +115,10 @@ pub(crate) fn load_u64(
     caller: Caller<Internal>,
     input: &[Val],
     output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &Internal = caller.data();
     let offset = args!(input, 0, i64) as usize;
-    let byte = data
-        .memory()
-        .load_u64(offset)
-        .map_err(|_| Trap::new("Read error"))?;
+    let byte = data.memory().load_u64(offset)?;
     output[0] = Val::I64(byte as i64);
     Ok(())
 }
@@ -140,7 +130,7 @@ pub(crate) fn output_set(
     mut caller: Caller<Internal>,
     input: &[Val],
     _output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &mut Internal = caller.data_mut();
     let (offset, length) = args!(input, (0, i64), (1, i64));
     data.output_offset = offset as usize;
@@ -155,7 +145,7 @@ pub(crate) fn alloc(
     mut caller: Caller<Internal>,
     input: &[Val],
     output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &mut Internal = caller.data_mut();
     let offs = data.memory_mut().alloc(input[0].unwrap_i64() as _)?;
     output[0] = Val::I64(offs.offset as i64);
@@ -170,7 +160,7 @@ pub(crate) fn free(
     mut caller: Caller<Internal>,
     input: &[Val],
     _output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &mut Internal = caller.data_mut();
     let offset = args!(input, 0, i64) as usize;
     data.memory_mut().free(offset);
@@ -184,7 +174,7 @@ pub(crate) fn error_set(
     mut caller: Caller<Internal>,
     input: &[Val],
     _output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &mut Internal = caller.data_mut();
     let offset = args!(input, 0, i64) as usize;
 
@@ -206,7 +196,7 @@ pub(crate) fn config_get(
     mut caller: Caller<Internal>,
     input: &[Val],
     output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &mut Internal = caller.data_mut();
     let plugin = data.plugin_mut();
 
@@ -231,7 +221,7 @@ pub(crate) fn var_get(
     mut caller: Caller<Internal>,
     input: &[Val],
     output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &mut Internal = caller.data_mut();
     let plugin = data.plugin_mut();
 
@@ -258,7 +248,7 @@ pub(crate) fn var_set(
     mut caller: Caller<Internal>,
     input: &[Val],
     _output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &mut Internal = caller.data_mut();
     let plugin = data.plugin_mut();
 
@@ -271,7 +261,7 @@ pub(crate) fn var_set(
 
     // If the store is larger than 100MB then stop adding things
     if size > 1024 * 1024 * 100 && voffset != 0 {
-        return Err(Trap::new("Variable store is full"));
+        return Err(Error::msg("Variable store is full"));
     }
 
     let key_offs = args!(input, 0, i64) as usize;
@@ -298,7 +288,7 @@ pub(crate) fn http_request(
     #[allow(unused_mut)] mut caller: Caller<Internal>,
     input: &[Val],
     output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     #[cfg(not(feature = "http"))]
     {
         let _ = (caller, input);
@@ -315,14 +305,13 @@ pub(crate) fn http_request(
         let http_req_offset = args!(input, 0, i64) as usize;
 
         let req: extism_manifest::HttpRequest =
-            serde_json::from_slice(data.memory().get(http_req_offset)?)
-                .map_err(|_| Trap::new("Invalid http request"))?;
+            serde_json::from_slice(data.memory().get(http_req_offset)?)?;
 
         let body_offset = args!(input, 1, i64) as usize;
 
         let url = match url::Url::parse(&req.url) {
             Ok(u) => u,
-            Err(e) => return Err(Trap::new(format!("Invalid URL: {e:?}"))),
+            Err(e) => return Err(Error::msg(format!("Invalid URL: {e:?}"))),
         };
         let allowed_hosts = &data.plugin().manifest.as_ref().allowed_hosts;
         let host_str = url.host_str().unwrap_or_default();
@@ -336,7 +325,7 @@ pub(crate) fn http_request(
                 pat.matches(host_str)
             });
             if !allowed_hosts.is_empty() && !host_matches_allowed {
-                return Err(Trap::new(format!(
+                return Err(Error::msg(format!(
                     "HTTP request to {} is not allowed",
                     req.url
                 )));
@@ -351,21 +340,18 @@ pub(crate) fn http_request(
 
         let res = if body_offset > 0 {
             let buf = data.memory().get(body_offset)?;
-            let res = r
-                .send_bytes(buf)
-                .map_err(|e| Trap::new(&format!("Request error: {e:?}")))?;
+            let res = r.send_bytes(buf)?;
             data.http_status = res.status();
             res.into_reader()
         } else {
-            let res = r.call().map_err(|e| Trap::new(format!("{:?}", e)))?;
+            let res = r.call()?;
             data.http_status = res.status();
             res.into_reader()
         };
 
         let mut buf = Vec::new();
         res.take(1024 * 1024 * 50) // TODO: make this limit configurable
-            .read_to_end(&mut buf)
-            .map_err(|e| Trap::new(format!("{:?}", e)))?;
+            .read_to_end(&mut buf)?;
 
         let mem = data.memory_mut().alloc_bytes(buf)?;
 
@@ -381,7 +367,7 @@ pub(crate) fn http_status_code(
     mut caller: Caller<Internal>,
     _input: &[Val],
     output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &mut Internal = caller.data_mut();
     output[0] = Val::I32(data.http_status as i32);
     Ok(())
@@ -394,7 +380,7 @@ pub(crate) fn length(
     mut caller: Caller<Internal>,
     input: &[Val],
     output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &mut Internal = caller.data_mut();
     let offset = args!(input, 0, i64) as usize;
     if offset == 0 {
@@ -403,7 +389,7 @@ pub(crate) fn length(
     }
     let length = match data.memory().block_length(offset) {
         Some(x) => x,
-        None => return Err(Trap::new("Unable to find length for offset")),
+        None => return Err(Error::msg("Unable to find length for offset")),
     };
     output[0] = Val::I64(length as i64);
     Ok(())
@@ -414,7 +400,7 @@ pub fn log(
     caller: Caller<Internal>,
     input: &[Val],
     _output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     let data: &Internal = caller.data();
     let offset = args!(input, 0, i64) as usize;
     let buf = data.memory().get(offset)?;
@@ -433,7 +419,7 @@ pub(crate) fn log_warn(
     caller: Caller<Internal>,
     input: &[Val],
     _output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     log(log::Level::Warn, caller, input, _output)
 }
 
@@ -444,7 +430,7 @@ pub(crate) fn log_info(
     caller: Caller<Internal>,
     input: &[Val],
     _output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     log(log::Level::Info, caller, input, _output)
 }
 
@@ -455,7 +441,7 @@ pub(crate) fn log_debug(
     caller: Caller<Internal>,
     input: &[Val],
     _output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     log(log::Level::Debug, caller, input, _output)
 }
 
@@ -466,6 +452,6 @@ pub(crate) fn log_error(
     caller: Caller<Internal>,
     input: &[Val],
     _output: &mut [Val],
-) -> Result<(), Trap> {
+) -> Result<(), Error> {
     log(log::Level::Error, caller, input, _output)
 }

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -221,8 +221,15 @@ pub unsafe extern "C" fn extism_plugin_call(
         None => return plugin.error(format!("Function not found: {name}"), -1),
     };
 
-    // Call function with offset+length pointing to input data.
+    // Check the number of results, reject functions with more than 1 result
     let n_results = func.ty(&plugin.memory.store).results().len();
+    if n_results > 1 {
+        return plugin.error(
+            format!("Function {name} has {n_results} results, expected 0 or 1"),
+            -1,
+        );
+    }
+
     let mut results = vec![Val::null(); n_results];
     match func.call(&mut plugin.memory.store, &[], results.as_mut_slice()) {
         Ok(r) => r,

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -230,6 +230,10 @@ pub unsafe extern "C" fn extism_plugin_call(
             plugin.dump_memory();
 
             if let Some(exit) = e.downcast_ref::<wasmtime_wasi::I32Exit>() {
+                error!("WASI return code: {}", exit.0);
+                if exit.0 != 0 {
+                    return plugin.error(&e, exit.0);
+                }
                 return exit.0;
             }
 

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -222,17 +222,29 @@ pub unsafe extern "C" fn extism_plugin_call(
     };
 
     // Call function with offset+length pointing to input data.
-    let mut results = vec![Val::I32(0)];
+    let n_results = func.ty(&plugin.memory.store).results().len();
+    let mut results = vec![Val::null(); n_results];
     match func.call(&mut plugin.memory.store, &[], results.as_mut_slice()) {
         Ok(r) => r,
         Err(e) => {
             plugin.dump_memory();
+
+            if let Some(exit) = e.downcast_ref::<wasmtime_wasi::I32Exit>() {
+                return exit.0;
+            }
+
             error!("Call: {e:?}");
             return plugin.error(e.context("Call failed"), -1);
         }
     };
 
     plugin.dump_memory();
+
+    // If `results` is empty then the return value is expected to be returned
+    // in the error block of the func call above using `I32Exit`
+    if results.is_empty() {
+        return 0;
+    }
 
     // Return result to caller
     results[0].unwrap_i32()


### PR DESCRIPTION
- Updates codebase to use the latest version of wasmtime, wasmtime-wasi and wasmtime-wasi-nn
- Allows functions with no return values to be called, this provides basic support for `_start` functions
  - For now `_start` functions called by extism still need to use the extism input/output functions instead of the command line arguments