### PR TITLE
docs(elixir-sdk): Reduce elixir min version

### DIFF
--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -5,7 +5,7 @@ defmodule Extism.MixProject do
     [
       app: :extism,
       version: "0.0.1",
-      elixir: "~> 1.14",
+      elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),


### PR DESCRIPTION
I've tested it in at least as low as 1.12. It just prints out a warning so should be fine if someone wants to use it on an older version.