### PR TITLE
fix: update crate name to extism_runtime in logging registration function

### DIFF
--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -405,7 +405,11 @@ pub unsafe extern "C" fn extism_log_file(
 
     let config = match Config::builder()
         .appender(Appender::builder().build("logfile", logfile))
-        .logger(Logger::builder().appender("logfile").build("extism", level))
+        .logger(
+            Logger::builder()
+                .appender("logfile")
+                .build("extism_runtime", level),
+        )
         .build(Root::builder().build(LevelFilter::Off))
     {
         Ok(x) => x,


### PR DESCRIPTION
This bug exists because we didn't change the crate name in the logging registration function, so all of our logs from `extism_runtime` were being filtered out.