### PR TITLE
feat: Improve usability of manifest types

### DIFF
--- a/extism.go
+++ b/extism.go
@@ -53,11 +53,11 @@ type WasmFile struct {
 }
 
 type WasmUrl struct {
-	Url    string            `json:"url"`
-	Hash   string            `json:"hash,omitempty"`
-	Header map[string]string `json:"header,omitempty"`
-	Name   string            `json:"name,omitempty"`
-	Method string            `json:"method,omitempty"`
+	Url     string            `json:"url"`
+	Hash    string            `json:"hash,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Name    string            `json:"name,omitempty"`
+	Method  string            `json:"method,omitempty"`
 }
 
 type Wasm interface{}
@@ -65,7 +65,7 @@ type Wasm interface{}
 type Manifest struct {
 	Wasm   []Wasm `json:"wasm"`
 	Memory struct {
-		Max uint32 `json:"max,omitempty"`
+		MaxPages uint32 `json:"max_pages,omitempty"`
 	} `json:"memory,omitempty"`
 	Config       map[string]string `json:"config,omitempty"`
 	AllowedHosts []string          `json:"allowed_hosts,omitempty"`

--- a/haskell/manifest/Extism/Manifest.hs
+++ b/haskell/manifest/Extism/Manifest.hs
@@ -43,14 +43,14 @@ instance JSONValue Memory where
 data HTTPRequest = HTTPRequest
   {
     url :: String
-  , header :: Maybe [(String, String)]
+  , headers :: Maybe [(String, String)]
   , method :: Maybe String
   }
 
-requestObj (HTTPRequest url header method) =
+requestObj (HTTPRequest url headers method) =
   [
     "url" .= url ,
-    "header" .= header,
+    "headers" .= headers,
     "method" .= method
   ]
 
@@ -118,7 +118,7 @@ wasmFile path =
 
 wasmURL :: String -> String -> Wasm
 wasmURL method url =
-  let r = HTTPRequest { url = url, header = Nothing, method = Just method } in
+  let r = HTTPRequest { url = url, headers = Nothing, method = Just method } in
   URL WasmURL { req = r, urlName = Nothing, urlHash = Nothing }
 
 wasmCode :: B.ByteString -> Wasm

--- a/manifest/schema.json
+++ b/manifest/schema.json
@@ -22,7 +22,7 @@
     },
     "memory": {
       "default": {
-        "max": null
+        "max_pages": null
       },
       "allOf": [
         {
@@ -42,7 +42,7 @@
     "MemoryOptions": {
       "type": "object",
       "properties": {
-        "max": {
+        "max_pages": {
           "type": [
             "integer",
             "null"
@@ -113,7 +113,7 @@
                 "null"
               ]
             },
-            "header": {
+            "headers": {
               "default": {},
               "type": "object",
               "additionalProperties": {

--- a/manifest/schema.json
+++ b/manifest/schema.json
@@ -22,11 +22,11 @@
     },
     "memory": {
       "default": {
-        "max": null
+        "max_pages": null
       },
       "allOf": [
         {
-          "$ref": "#/definitions/ManifestMemory"
+          "$ref": "#/definitions/MemoryOptions"
         }
       ]
     },
@@ -34,15 +34,15 @@
       "default": [],
       "type": "array",
       "items": {
-        "$ref": "#/definitions/ManifestWasm"
+        "$ref": "#/definitions/Wasm"
       }
     }
   },
   "definitions": {
-    "ManifestMemory": {
+    "MemoryOptions": {
       "type": "object",
       "properties": {
-        "max": {
+        "max_pages": {
           "type": [
             "integer",
             "null"
@@ -52,7 +52,7 @@
         }
       }
     },
-    "ManifestWasm": {
+    "Wasm": {
       "anyOf": [
         {
           "type": "object",

--- a/manifest/schema.json
+++ b/manifest/schema.json
@@ -22,7 +22,7 @@
     },
     "memory": {
       "default": {
-        "max_pages": null
+        "max": null
       },
       "allOf": [
         {
@@ -42,7 +42,7 @@
     "MemoryOptions": {
       "type": "object",
       "properties": {
-        "max_pages": {
+        "max": {
           "type": [
             "integer",
             "null"

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -6,8 +6,8 @@ pub type ManifestMemory = MemoryOptions;
 #[derive(Default, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 pub struct MemoryOptions {
-    #[serde(alias = "max_pages")]
-    pub max: Option<u32>,
+    #[serde(alias = "max")]
+    pub max_pages: Option<u32>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -15,8 +15,8 @@ pub struct MemoryOptions {
 pub struct HttpRequest {
     pub url: String,
     #[serde(default)]
-    #[serde(alias = "headers")]
-    pub header: std::collections::BTreeMap<String, String>,
+    #[serde(alias = "header")]
+    pub headers: std::collections::BTreeMap<String, String>,
     pub method: Option<String>,
 }
 
@@ -24,7 +24,7 @@ impl HttpRequest {
     pub fn new(url: impl Into<String>) -> HttpRequest {
         HttpRequest {
             url: url.into(),
-            header: Default::default(),
+            headers: Default::default(),
             method: None,
         }
     }
@@ -35,7 +35,7 @@ impl HttpRequest {
     }
 
     pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> HttpRequest {
-        self.header.insert(key.into(), value.into());
+        self.headers.insert(key.into(), value.into());
         self
     }
 }

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -43,6 +43,33 @@ pub struct WasmMetadata {
     pub hash: Option<String>,
 }
 
+impl From<HttpRequest> for Wasm {
+    fn from(req: HttpRequest) -> Self {
+        Wasm::Url {
+            req,
+            meta: WasmMetadata::default(),
+        }
+    }
+}
+
+impl From<std::path::PathBuf> for Wasm {
+    fn from(path: std::path::PathBuf) -> Self {
+        Wasm::File {
+            path,
+            meta: WasmMetadata::default(),
+        }
+    }
+}
+
+impl From<Vec<u8>> for Wasm {
+    fn from(data: Vec<u8>) -> Self {
+        Wasm::Data {
+            data,
+            meta: WasmMetadata::default(),
+        }
+    }
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 #[serde(untagged)]

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -15,6 +15,7 @@ pub struct MemoryOptions {
 pub struct HttpRequest {
     pub url: String,
     #[serde(default)]
+    #[serde(alias = "headers")]
     pub header: std::collections::BTreeMap<String, String>,
     pub method: Option<String>,
 }

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -1,10 +1,13 @@
 use std::collections::BTreeMap;
 
+#[deprecated]
+pub type ManifestMemory = MemoryOptions;
+
 #[derive(Default, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]
 pub struct MemoryOptions {
-    #[serde(alias = "max")]
-    pub max_pages: Option<u32>,
+    #[serde(alias = "max_pages")]
+    pub max: Option<u32>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -69,6 +72,9 @@ impl From<Vec<u8>> for Wasm {
         }
     }
 }
+
+#[deprecated]
+pub type ManifestWasm = Wasm;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "json_schema", derive(schemars::JsonSchema))]

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -161,6 +161,16 @@ pub struct Manifest {
     pub allowed_hosts: Option<Vec<String>>,
 }
 
+impl Manifest {
+    /// Create a new manifest
+    pub fn new(wasm: impl Into<Vec<Wasm>>) -> Manifest {
+        Manifest {
+            wasm: wasm.into(),
+            ..Default::default()
+        }
+    }
+}
+
 mod base64 {
     use serde::{Deserialize, Serialize};
     use serde::{Deserializer, Serializer};

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -145,7 +145,7 @@ export type ManifestWasmData = {
  * Memory options for the {@link Plugin}
  */
 export type ManifestMemory = {
-  max?: number;
+  max_pages?: number;
 };
 
 /**

--- a/ocaml/lib/extism.ml
+++ b/ocaml/lib/extism.ml
@@ -93,7 +93,7 @@ end
 type error = [ `Msg of string ]
 
 module Manifest = struct
-  type memory = { max : int option [@yojson.option] } [@@deriving yojson]
+  type memory = { max_pages : int option [@yojson.option] } [@@deriving yojson]
 
   type wasm_file = {
     path : string;
@@ -116,7 +116,7 @@ module Manifest = struct
 
   type wasm_url = {
     url : string;
-    header : (string * string) list option; [@yojson.option]
+    headers : (string * string) list option; [@yojson.option]
     name : string option; [@yojson.option]
     meth : string option; [@yojson.option] [@key "method"]
     hash : string option; [@yojson.option]
@@ -161,7 +161,7 @@ module Manifest = struct
 
   let file ?name ?hash path = File { path; name; hash }
   let data ?name ?hash data = Data { data; name; hash }
-  let url ?header ?name ?meth ?hash url = Url { header; name; meth; hash; url }
+  let url ?headers ?name ?meth ?hash url = Url { headers; name; meth; hash; url }
 
   let v ?config ?memory ?allowed_hosts wasm =
     { config; wasm; memory; allowed_hosts }

--- a/ocaml/lib/extism.mli
+++ b/ocaml/lib/extism.mli
@@ -4,7 +4,7 @@ type error = [ `Msg of string ]
 val extism_version : unit -> string
 
 module Manifest : sig
-  type memory = { max : int option } [@@deriving yojson]
+  type memory = { max_pages : int option } [@@deriving yojson]
 
   type wasm_file = {
     path : string;
@@ -20,7 +20,7 @@ module Manifest : sig
 
   type wasm_url = {
     url : string;
-    header : (string * string) list option; [@yojson.option]
+    headers : (string * string) list option; [@yojson.option]
     name : string option; [@yojson.option]
     meth : string option; [@yojson.option] [@key "method"]
     hash : string option; [@yojson.option]
@@ -40,7 +40,7 @@ module Manifest : sig
   val data : ?name:string -> ?hash:string -> string -> wasm
 
   val url :
-    ?header:(string * string) list ->
+    ?headers:(string * string) list ->
     ?name:string ->
     ?meth:string ->
     ?hash:string ->

--- a/python/tests/test_extism.py
+++ b/python/tests/test_extism.py
@@ -66,7 +66,7 @@ class TestExtism(unittest.TestCase):
     def _manifest(self):
         wasm = self._count_vowels_wasm()
         hash = hashlib.sha256(wasm).hexdigest()
-        return {"wasm": [{"data": wasm, "hash": hash}], "memory": {"max": 5}}
+        return {"wasm": [{"data": wasm, "hash": hash}], "memory": {"max_pages": 5}}
 
     def _count_vowels_wasm(self):
         path = join(dirname(__file__), "code.wasm")

--- a/runtime/src/manifest.rs
+++ b/runtime/src/manifest.rs
@@ -61,18 +61,15 @@ fn check_hash(hash: &Option<String>, data: &[u8]) -> Result<(), Error> {
 }
 
 /// Convert from manifest to a wasmtime Module
-fn to_module(
-    engine: &Engine,
-    wasm: &extism_manifest::ManifestWasm,
-) -> Result<(String, Module), Error> {
+fn to_module(engine: &Engine, wasm: &extism_manifest::Wasm) -> Result<(String, Module), Error> {
     match wasm {
-        extism_manifest::ManifestWasm::File { path, name, hash } => {
+        extism_manifest::Wasm::File { path, meta } => {
             if cfg!(not(feature = "register-filesystem")) {
                 return Err(anyhow::format_err!("File-based registration is disabled"));
             }
 
             // Figure out a good name for the file
-            let name = match name {
+            let name = match &meta.name {
                 None => {
                     let name = path.with_extension("");
                     name.file_name().unwrap().to_string_lossy().to_string()
@@ -85,31 +82,30 @@ fn to_module(
             let mut file = std::fs::File::open(path)?;
             file.read_to_end(&mut buf)?;
 
-            check_hash(hash, &buf)?;
+            check_hash(&meta.hash, &buf)?;
 
             Ok((name, Module::new(engine, buf)?))
         }
-        extism_manifest::ManifestWasm::Data { name, data, hash } => {
-            check_hash(hash, data)?;
+        extism_manifest::Wasm::Data { meta, data } => {
+            check_hash(&meta.hash, data)?;
             Ok((
-                name.as_deref().unwrap_or("main").to_string(),
+                meta.name.as_deref().unwrap_or("main").to_string(),
                 Module::new(engine, data)?,
             ))
         }
         #[allow(unused)]
-        extism_manifest::ManifestWasm::Url {
-            name,
+        extism_manifest::Wasm::Url {
             req:
                 extism_manifest::HttpRequest {
                     url,
                     header,
                     method,
                 },
-            hash,
+            meta,
         } => {
             // Get the file name
             let file_name = url.split('/').last().unwrap_or_default();
-            let name = match name {
+            let name = match &meta.name {
                 Some(name) => name.as_str(),
                 None => {
                     let mut name = "main";
@@ -124,9 +120,9 @@ fn to_module(
                 }
             };
 
-            if let Some(h) = hash {
+            if let Some(h) = &meta.hash {
                 if let Ok(Some(data)) = cache_get_file(h) {
-                    check_hash(hash, &data)?;
+                    check_hash(&meta.hash, &data)?;
                     let module = Module::new(engine, data)?;
                     return Ok((name.to_string(), module));
                 }
@@ -152,11 +148,11 @@ fn to_module(
                 r.read_to_end(&mut data)?;
 
                 // Try to cache file
-                if let Some(hash) = hash {
+                if let Some(hash) = &meta.hash {
                     cache_add_file(hash, &data);
                 }
 
-                check_hash(hash, &data)?;
+                check_hash(&meta.hash, &data)?;
 
                 // Convert fetched data to module
                 let module = Module::new(engine, data)?;

--- a/runtime/src/manifest.rs
+++ b/runtime/src/manifest.rs
@@ -98,7 +98,7 @@ fn to_module(engine: &Engine, wasm: &extism_manifest::Wasm) -> Result<(String, M
             req:
                 extism_manifest::HttpRequest {
                     url,
-                    header,
+                    headers,
                     method,
                 },
             meta,
@@ -138,7 +138,7 @@ fn to_module(engine: &Engine, wasm: &extism_manifest::Wasm) -> Result<(String, M
                 // Setup request
                 let mut req = ureq::request(method.as_deref().unwrap_or("GET"), url);
 
-                for (k, v) in header.iter() {
+                for (k, v) in headers.iter() {
                     req = req.set(k, v);
                 }
 

--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -334,7 +334,7 @@ pub(crate) fn http_request(
 
         let mut r = ureq::request(req.method.as_deref().unwrap_or("GET"), &req.url);
 
-        for (k, v) in req.header.iter() {
+        for (k, v) in req.headers.iter() {
             r = r.set(k, v);
         }
 

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -90,10 +90,7 @@ impl Plugin {
         let engine = Engine::default();
         let (manifest, modules) = Manifest::new(&engine, wasm.as_ref())?;
         let mut store = Store::new(&engine, Internal::new(&manifest, with_wasi)?);
-        let memory = Memory::new(
-            &mut store,
-            MemoryType::new(4, manifest.as_ref().memory.max_pages),
-        )?;
+        let memory = Memory::new(&mut store, MemoryType::new(4, manifest.as_ref().memory.max))?;
         let mut memory = PluginMemory::new(store, memory);
 
         let mut linker = Linker::new(&engine);

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -90,7 +90,10 @@ impl Plugin {
         let engine = Engine::default();
         let (manifest, modules) = Manifest::new(&engine, wasm.as_ref())?;
         let mut store = Store::new(&engine, Internal::new(&manifest, with_wasi)?);
-        let memory = Memory::new(&mut store, MemoryType::new(4, manifest.as_ref().memory.max))?;
+        let memory = Memory::new(
+            &mut store,
+            MemoryType::new(4, manifest.as_ref().memory.max_pages),
+        )?;
         let mut memory = PluginMemory::new(store, memory);
 
         let mut linker = Linker::new(&engine);


### PR DESCRIPTION
- Adds some helper functions for creating a manifest, mostly helpful for the Rust SDK
- Renames `ManifestWasm` to `Wasm`
- Renames `ManifestMemory` to `MemoryOptions`
- `ManifestWasm` and `ManifestMemory` have been marked as deprecated
- Adds an alias from `MemoryOptions::max_pages` to `MemoryOptions::max` in serde specification