### PR TITLE
feat: Java Host SDK

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,11 +8,20 @@
   <name>extism</name>
   <url>http://maven.apache.org</url>
   <properties>
-    <maven.compiler.source>19</maven.compiler.source>
-    <maven.compiler.target>19</maven.compiler.target>
+    <java.version>19</java.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
+        <configuration>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
+        </configuration>
+      </plugin>
       <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
           <configuration>
@@ -35,6 +44,16 @@
               </execution>
           </executions>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.22.2</version>
+            <configuration>
+                <systemPropertyVariables>
+                    <jna.library.path>../target/release</jna.library.path>
+                </systemPropertyVariables>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/java/src/main/java/org/extism/sdk/LibExtism.java
+++ b/java/src/main/java/org/extism/sdk/LibExtism.java
@@ -4,10 +4,15 @@ import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
-//import com.sun.jna.Platform;
 
 public interface LibExtism extends Library {
-    LibExtism INSTANCE = (LibExtism) Native.loadLibrary("/usr/local/lib/libextism.dylib", LibExtism.class);
+
+    /**
+     * Holds the extism library instance.
+     *
+     * Resolves the extism library based on the resolution algorithm defined in {@link com.sun.jna.NativeLibrary}.
+     */
+    LibExtism INSTANCE = Native.loadLibrary("extism", LibExtism.class);
 
     Pointer extism_context_new();
 

--- a/java/src/test/java/org/extism/sdk/ExtismTest.java
+++ b/java/src/test/java/org/extism/sdk/ExtismTest.java
@@ -26,7 +26,7 @@ public class ExtismTest extends TestCase {
         return new TestSuite( ExtismTest.class );
     }
 
-    public void testApp() throws IOException {
+    public void testApp() {
         Path resourceDirectory = Paths.get("src", "test", "resources", "code.wasm");
         String absolutePath = resourceDirectory.toFile().getAbsolutePath();
         Context ctx = new Context();


### PR DESCRIPTION
We now resolve the extism library dynamically based on the rules
defined in com.sun.jna.NativeLibrary.

For tests we resolve the library relative to the cwd based on the
jna.library.path system property set to ../target/release.

Improves #117