### PR TITLE
fix: Reinstantiate after call to `_start`

### DIFF
--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -231,4 +231,8 @@ impl Plugin {
         self.instance = instance;
         Ok(())
     }
+
+    pub fn has_wasi(&self) -> bool {
+        self.memory.store.data().wasi.is_some()
+    }
 }

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -90,7 +90,10 @@ impl Plugin {
         let engine = Engine::default();
         let (manifest, modules) = Manifest::new(&engine, wasm.as_ref())?;
         let mut store = Store::new(&engine, Internal::new(&manifest, with_wasi)?);
-        let memory = Memory::new(&mut store, MemoryType::new(4, manifest.as_ref().memory.max))?;
+        let memory = Memory::new(
+            &mut store,
+            MemoryType::new(20, manifest.as_ref().memory.max),
+        )?;
         let mut memory = PluginMemory::new(store, memory);
 
         let mut linker = Linker::new(&engine);
@@ -136,6 +139,11 @@ impl Plugin {
                 use ValType::*;
 
                 if module_name == EXPORT_MODULE_NAME {
+                    linker.define(
+                        EXPORT_MODULE_NAME,
+                        "memory",
+                        Extern::Memory(memory.memory.clone()),
+                    )?;
                     define_funcs!(name,  {
                         alloc(I64) -> I64;
                         free(I64);
@@ -220,5 +228,13 @@ impl Plugin {
 
     pub fn dump_memory(&self) {
         self.memory.dump();
+    }
+
+    pub fn reinstantiate(&mut self) {
+        let instance = self
+            .linker
+            .instantiate(&mut self.memory.store, &self.module)
+            .unwrap();
+        self.instance = instance;
     }
 }

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -11,6 +11,7 @@ pub struct Plugin {
     pub memory: PluginMemory,
     pub manifest: Manifest,
     pub vars: BTreeMap<String, Vec<u8>>,
+    pub should_reinstantiate: bool,
 }
 
 pub struct Internal {
@@ -189,6 +190,7 @@ impl Plugin {
             last_error: std::cell::RefCell::new(None),
             manifest,
             vars: BTreeMap::new(),
+            should_reinstantiate: false,
         })
     }
 
@@ -230,11 +232,11 @@ impl Plugin {
         self.memory.dump();
     }
 
-    pub fn reinstantiate(&mut self) {
+    pub fn reinstantiate(&mut self) -> Result<(), Error> {
         let instance = self
             .linker
-            .instantiate(&mut self.memory.store, &self.module)
-            .unwrap();
+            .instantiate(&mut self.memory.store, &self.module)?;
         self.instance = instance;
+        Ok(())
     }
 }

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -91,10 +91,7 @@ impl Plugin {
         let engine = Engine::default();
         let (manifest, modules) = Manifest::new(&engine, wasm.as_ref())?;
         let mut store = Store::new(&engine, Internal::new(&manifest, with_wasi)?);
-        let memory = Memory::new(
-            &mut store,
-            MemoryType::new(20, manifest.as_ref().memory.max),
-        )?;
+        let memory = Memory::new(&mut store, MemoryType::new(4, manifest.as_ref().memory.max))?;
         let mut memory = PluginMemory::new(store, memory);
 
         let mut linker = Linker::new(&engine);
@@ -140,11 +137,6 @@ impl Plugin {
                 use ValType::*;
 
                 if module_name == EXPORT_MODULE_NAME {
-                    linker.define(
-                        EXPORT_MODULE_NAME,
-                        "memory",
-                        Extern::Memory(memory.memory.clone()),
-                    )?;
                     define_funcs!(name,  {
                         alloc(I64) -> I64;
                         free(I64);

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -236,6 +236,10 @@ pub unsafe extern "C" fn extism_plugin_call(
         Err(e) => {
             plugin.dump_memory();
 
+            if name == "_start" {
+                plugin.reinstantiate()
+            }
+
             if let Some(exit) = e.downcast_ref::<wasmtime_wasi::I32Exit>() {
                 error!("WASI return code: {}", exit.0);
                 if exit.0 != 0 {
@@ -250,6 +254,10 @@ pub unsafe extern "C" fn extism_plugin_call(
     };
 
     plugin.dump_memory();
+
+    if name == "_start" {
+        plugin.reinstantiate();
+    }
 
     // If `results` is empty then the return value is expected to be returned
     // in the error block of the func call above using `I32Exit`

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -235,7 +235,7 @@ pub unsafe extern "C" fn extism_plugin_call(
 
     plugin.dump_memory();
 
-    if name == "_start" {
+    if plugin.has_wasi() && name == "_start" {
         plugin.should_reinstantiate = true;
     }
 

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -243,7 +243,7 @@ pub unsafe extern "C" fn extism_plugin_call(
         Ok(()) => (),
         Err(e) => {
             if let Some(exit) = e.downcast_ref::<wasmtime_wasi::I32Exit>() {
-                error!("WASI return code: {}", exit.0);
+                trace!("WASI return code: {}", exit.0);
                 if exit.0 != 0 {
                     return plugin.error(&e, exit.0);
                 }

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -236,10 +236,7 @@ pub unsafe extern "C" fn extism_plugin_call(
     plugin.dump_memory();
 
     if name == "_start" {
-        // Reinstantiate plugin after calling _start because according to the WASI
-        // applicate ABI _start should be called "at most once":
-        // https://github.com/WebAssembly/WASI/blob/main/legacy/application-abi.md
-        plugin.reinstantiate()
+        plugin.should_reinstantiate = true;
     }
 
     match res {


### PR DESCRIPTION
After a closer reading of: https://github.com/WebAssembly/WASI/blob/main/legacy/application-abi.md it looks likes `_start` is expected to be called at most once. This PR automatically reinstantiates a plugin after a call to `_start` so it can be used again.

CI caught a bug with the `extism_version` output which is fixed here: https://github.com/extism/extism/pull/139