### PR TITLE
Refactor java-sdk

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,9 +6,9 @@
   <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
   <name>extism</name>
-  <url>http://maven.apache.org</url>
+  <url>https://github.com/extism/extism</url>
   <properties>
-    <java.version>19</java.version>
+    <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <build>
@@ -18,8 +18,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.10.1</version>
         <configuration>
-            <source>${java.version}</source>
-            <target>${java.version}</target>
+            <release>${java.version}</release>
         </configuration>
       </plugin>
       <plugin>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -68,9 +68,15 @@
       <version>2.10</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.9.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.23.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/src/main/java/org/extism/sdk/Context.java
+++ b/java/src/main/java/org/extism/sdk/Context.java
@@ -1,19 +1,23 @@
 package org.extism.sdk;
 
-import org.extism.sdk.manifest.ManifestWasmData;
-import org.extism.sdk.manifest.ManifestWasm;
 import org.extism.sdk.manifest.Manifest;
 
 import com.sun.jna.Pointer;
 
-// ExtismContext is used to store and manage plugins
-public class Context {
-
-    // A pointer to the ExtismContext struct
-    private Pointer contextPointer;
+/**
+ * Extism Context is used to store and manage plugins.
+ */
+public class Context implements AutoCloseable {
 
     /**
-     * Create a new Context. A Context is used to manage Plugins
+     * Holds a pointer to the ExtismContext struct.
+     */
+    private final Pointer contextPointer;
+
+    /**
+     * Creates a new context.
+     * <p>
+     * A Context is used to manage Plugins
      * and make sure they are cleaned up when you are done with them.
      */
     public Context() {
@@ -50,21 +54,35 @@ public class Context {
 
     /**
      * Get the version string of the linked Extism Runtime.
-     * 
-     * @return
+     *
+     * @return the version
      */
     public String getVersion() {
         return LibExtism.INSTANCE.extism_version();
     }
 
-    // Get the error associated with a context, if plugin is null then the context
-    // error will be returned
-    protected String error(Plugin plugin) {
+    /**
+     * Get the error associated with a context, if plugin is {@literal null} then the context error will be returned.
+     * @param plugin
+     * @return
+     */
+    public String error(Plugin plugin) {
         return LibExtism.INSTANCE.extism_error(this.contextPointer, plugin == null ? -1 : plugin.getIndex());
     }
 
-    protected Pointer getPointer() {
+    /**
+     * Return the raw pointer to this context.
+     * @return
+     */
+    public Pointer getPointer() {
         return this.contextPointer;
     }
 
+    /**
+     * Calls {@link #free()} if used in the context of a TWR block.
+     */
+    @Override
+    public void close() {
+        this.free();
+    }
 }

--- a/java/src/main/java/org/extism/sdk/ExtismException.java
+++ b/java/src/main/java/org/extism/sdk/ExtismException.java
@@ -1,0 +1,15 @@
+package org.extism.sdk;
+
+public class ExtismException extends RuntimeException {
+
+    public ExtismException() {
+    }
+
+    public ExtismException(String message) {
+        super(message);
+    }
+
+    public ExtismException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/java/src/main/java/org/extism/sdk/LibExtism.java
+++ b/java/src/main/java/org/extism/sdk/LibExtism.java
@@ -5,39 +5,131 @@ import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 
+/**
+ * Wrapper around the Extism library.
+ */
 public interface LibExtism extends Library {
 
     /**
      * Holds the extism library instance.
-     *
      * Resolves the extism library based on the resolution algorithm defined in {@link com.sun.jna.NativeLibrary}.
      */
     LibExtism INSTANCE = Native.loadLibrary("extism", LibExtism.class);
 
+    /**
+     * Create a new context
+     */
     Pointer extism_context_new();
 
+    /**
+     * Free a context
+     */
     void extism_context_free(Pointer contextPointer);
 
+    /**
+     * Remove all plugins from the registry.
+     *
+     * @param contextPointer
+     */
     void extism_context_reset(Pointer contextPointer);
 
+    /**
+     * Returns the error associated with a @{@link Context} or @{@link Plugin}, if {@code pluginId} is {@literal -1} then the context error will be returned
+     *
+     * @param contextPointer
+     * @param pluginId
+     * @return
+     */
     String extism_error(Pointer contextPointer, int pluginId);
 
+    /**
+     * Create a new plugin.
+     *
+     * @param contextPointer pointer to the {@link Context}.
+     * @param wasm           is a WASM module (wat or wasm) or a JSON encoded manifest
+     * @param wasmSize       the length of the `wasm` parameter
+     * @param withWASI       enables/disables WASI
+     * @return id of the plugin
+     */
     int extism_plugin_new(long contextPointer, byte[] wasm, long wasmSize, boolean withWASI);
 
+    /**
+     * Returns the Extism version string
+     */
     String extism_version();
 
-    void extism_plugin_new(Pointer contextPointer, byte[] wasm, int length, boolean withWASI,
-            IntByReference pluginIndex);
+    /**
+     * Create a new plugin.
+     *
+     * @param contextPointer pointer to the {@link Context}.
+     * @param wasm           is a WASM module (wat or wasm) or a JSON encoded manifest
+     * @param length         the length of the `wasm` parameter
+     * @param withWASI       enables/disables WASI
+     * @param pluginIndex    output parameter for the plugin id.
+     * @see #extism_plugin_new(long, byte[], long, boolean)
+     */
+    void extism_plugin_new(Pointer contextPointer, byte[] wasm, int length, boolean withWASI, IntByReference pluginIndex);
 
-    int extism_plugin_call(Pointer contextPointer, int pluginIndex, String function_name, byte[] wasm, int length);
+    /**
+     * Calls a function from the @{@link Plugin} at the given {@code pluginIndex}.
+     *
+     * @param contextPointer
+     * @param pluginIndex
+     * @param function_name  is the function to call
+     * @param data           is the data input data
+     * @param dataLength     is the data input data length
+     * @return the result code of the plugin call.
+     */
+    int extism_plugin_call(Pointer contextPointer, int pluginIndex, String function_name, byte[] data, int dataLength);
 
+    /**
+     * Returns the length of a plugin's output data.
+     *
+     * @param contextPointer
+     * @param pluginIndex
+     * @return
+     */
     int extism_plugin_output_length(Pointer contextPointer, int pluginIndex);
 
+    /**
+     * Returns the plugin's output data.
+     *
+     * @param contextPointer
+     * @param pluginIndex
+     * @return
+     */
     Pointer extism_plugin_output_data(Pointer contextPointer, int pluginIndex);
 
+    /**
+     * Update a plugin, keeping the existing ID.
+     * Similar to {@link #extism_plugin_new(long, byte[], long, boolean)} but takes an {@code pluginIndex} argument to specify which plugin to update.
+     * Note: Memory for this plugin will be reset upon update.
+     *
+     * @param contextPointer
+     * @param pluginIndex
+     * @param wasm
+     * @param length
+     * @param withWASI
+     * @return
+     */
     boolean extism_plugin_update(Pointer contextPointer, int pluginIndex, byte[] wasm, int length, boolean withWASI);
 
+    /**
+     * Remove a plugin from the registry and free associated memory.
+     *
+     * @param contextPointer
+     * @param pluginIndex
+     */
     void extism_plugin_free(Pointer contextPointer, int pluginIndex);
 
+    /**
+     * Update plugin config values, this will merge with the existing values.
+     *
+     * @param contextPointer
+     * @param pluginIndex
+     * @param json
+     * @param jsonLength
+     * @return
+     */
     boolean extism_plugin_config(Pointer contextPointer, int pluginIndex, byte[] json, int jsonLength);
 }

--- a/java/src/main/java/org/extism/sdk/Plugin.java
+++ b/java/src/main/java/org/extism/sdk/Plugin.java
@@ -1,84 +1,145 @@
 package org.extism.sdk;
 
-import org.extism.sdk.manifest.Manifest;
-
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
+import org.extism.sdk.manifest.Manifest;
+import org.extism.sdk.support.JsonSerializer;
 
-// Represents a plugin
-public class Plugin {
-    // The ExtismContext that the plugin belongs to
-    private Context context;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
-    // The index of the plugin
-    private int index;
+/**
+ * Represents a Extism plugin.
+ */
+public class Plugin implements AutoCloseable {
+
+    /**
+     * Holds the The Extism {@link Context} that the plugin belongs to.
+     */
+    private final Context context;
+
+    /**
+     * Holds the index of the plugin
+     */
+    private final int index;
 
     /**
      * Constructor for a Plugin. Only expose internally. Plugins should be created and
      * managed from {@link org.extism.sdk.Context}.
-     * 
+     *
      * @param context The context to manage the plugin
-     * @param manifest The manifest for the plugin
+     * @param manifestBytes The manifest for the plugin
      * @param withWASI Set to true to enable WASI
      */
-    protected Plugin(Context context, Manifest manifest, boolean withWASI) {
-        byte[] manifestJson = manifest.toJson().getBytes();
-        this.context = context;
+    public Plugin(Context context, byte[] manifestBytes, boolean withWASI) {
+
+        Objects.requireNonNull(context, "context");
+        Objects.requireNonNull(manifestBytes, "manifestBytes");
+
         IntByReference pluginIndex = new IntByReference();
-        LibExtism.INSTANCE.extism_plugin_new(context.getPointer(), manifestJson, manifestJson.length, withWASI, pluginIndex);
+        LibExtism.INSTANCE.extism_plugin_new(context.getPointer(), manifestBytes, manifestBytes.length, withWASI, pluginIndex);
         this.index = pluginIndex.getValue();
+        this.context = context;
+    }
+
+    public Plugin(Context context, Manifest manifest, boolean withWASI) {
+        this(context, JsonSerializer.toJson(manifest).getBytes(), withWASI);
     }
 
     /**
-     * Getter for the internal index pointer to this plugin
-     * @return 
+     * Getter for the internal index pointer to this plugin.
+     * @return
      */
-    protected int getIndex() {
+    public int getIndex() {
         return this.index;
     }
 
     /**
-     * Invoke a function with the given name and input
-     * 
-     * @param function_name The name of the exported function to invoke
+     * Invoke a function with the given name and input.
+     *
+     * @param functionName The name of the exported function to invoke
      * @param inputData The raw bytes representing any input data
      * @return A byte array representing the raw output data
      */
-    public byte[] call(String function_name, byte[] inputData) {
-        int _result = LibExtism.INSTANCE.extism_plugin_call(this.context.getPointer(), this.index, function_name, inputData, inputData.length);
+    public byte[] call(String functionName, byte[] inputData) {
+        int result = LibExtism.INSTANCE.extism_plugin_call(this.context.getPointer(), this.index, functionName, inputData, inputData.length);
+        if (result == -1) {
+            throw new ExtismException("Call returned -1");
+        }
         int length = LibExtism.INSTANCE.extism_plugin_output_length(this.context.getPointer(), this.index);
         Pointer output = LibExtism.INSTANCE.extism_plugin_output_data(this.context.getPointer(), this.index);
         return output.getByteArray(0, length);
     }
 
     /**
+     * Invoke a function with the given name and input.
+     *
+     * @param functionName The name of the exported function to invoke
+     * @param input The string representing the input data
+     * @return A string representing the output data
+     */
+    public String call(String functionName, String input) {
+        var inputBytes = input.getBytes(StandardCharsets.UTF_8);
+        var outputBytes = call(functionName, inputBytes);
+        return new String(outputBytes, StandardCharsets.UTF_8);
+    }
+
+    /**
      * Update the plugin code given manifest changes
-     * 
+     *
      * @param manifest The manifest for the plugin
      * @param withWASI Set to true to enable WASI
      * @return Returns true if update was successful
      */
     public boolean update(Manifest manifest, boolean withWASI) {
-        byte[] manifestJson = manifest.toJson().getBytes();
-        return LibExtism.INSTANCE.extism_plugin_update(this.context.getPointer(), this.index, manifestJson, manifestJson.length,
-                withWASI);
+        byte[] manifestBytes = JsonSerializer.toJson(manifest).getBytes(StandardCharsets.UTF_8);
+        return update(manifestBytes,withWASI);
+    }
+
+    /**
+     * Update the plugin code given manifest changes
+     *
+     * @param manifestBytes The manifest for the plugin
+     * @param withWASI Set to true to enable WASI
+     * @return Returns true if update was successful
+     */
+    public boolean update(byte[] manifestBytes, boolean withWASI) {
+        return LibExtism.INSTANCE.extism_plugin_update(this.context.getPointer(), this.index, manifestBytes, manifestBytes.length, withWASI);
     }
 
     /**
      * Frees a plugin from memory. Plugins will be automatically cleaned up
-     * if you free their parent Context using {@link org.extism.sdk.Context#free() free()} or {@link org.extism.sdk.Context#reset() reset()} 
+     * if you free their parent Context using {@link org.extism.sdk.Context#free() free()} or {@link org.extism.sdk.Context#reset() reset()}
      */
     public void free() {
         LibExtism.INSTANCE.extism_plugin_free(this.context.getPointer(), this.index);
     }
 
     /**
-     * Update the config for the plugin
-     * 
+     * Update plugin config values, this will merge with the existing values.
+     *
      * @param json
      * @return
      */
-    public boolean config(byte[] json) {
-        return LibExtism.INSTANCE.extism_plugin_config(this.context.getPointer(), this.index, json, json.length);
+    public boolean updateConfig(String json) {
+        return updateConfig(json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Update plugin config values, this will merge with the existing values.
+     *
+     * @param jsonBytes
+     * @return
+     */
+    public boolean updateConfig(byte[] jsonBytes) {
+        return LibExtism.INSTANCE.extism_plugin_config(this.context.getPointer(), this.index, jsonBytes, jsonBytes.length);
+    }
+
+    /**
+     * Calls {@link #free()} if used in the context of a TWR block.
+     */
+    @Override
+    public void close() {
+        free();
     }
 }

--- a/java/src/main/java/org/extism/sdk/manifest/Manifest.java
+++ b/java/src/main/java/org/extism/sdk/manifest/Manifest.java
@@ -1,27 +1,64 @@
 package org.extism.sdk.manifest;
 
+import org.extism.sdk.wasm.WasmSource;
+
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import com.google.gson.GsonBuilder;
-import com.google.gson.Gson;
-import com.google.gson.FieldNamingPolicy;
 
 public class Manifest {
-    public List<ManifestWasm> wasm;
-    public ManifestMemory memory;
-    public List<String> allowedHosts;
-    public Map<String, String> config;
 
-    private static Gson _gson;
-    static {
-        Manifest._gson = new GsonBuilder()
-            .disableHtmlEscaping()
-            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-            .setPrettyPrinting()
-            .create();
+    private final List<WasmSource> wasm;
+
+    private final ManifestMemory memory;
+
+    private final List<String> allowedHosts;
+
+    private final Map<String, String> config;
+
+    public Manifest() {
+        this(new ArrayList<>(), null, null, null);
     }
 
-    public String toJson() {
-        return _gson.toJson(this);
+    public Manifest(List<WasmSource> sources) {
+        this(sources, null, null, null);
+    }
+
+    public Manifest(List<WasmSource> sources, ManifestMemory memory) {
+        this(sources, memory, null, null);
+    }
+
+    public Manifest(List<WasmSource> sources, ManifestMemory memory, Map<String, String> config, List<String> allowedHosts) {
+        this.wasm = sources;
+        this.memory = memory;
+        this.config = config;
+        this.allowedHosts = allowedHosts;
+    }
+
+    public void addSource(WasmSource source) {
+        this.wasm.add(source);
+    }
+
+    public List<WasmSource> getSources() {
+        return Collections.unmodifiableList(wasm);
+    }
+
+    public ManifestMemory getMemory() {
+        return memory;
+    }
+
+    public Map<String, String> getConfig() {
+        if (config == null || config.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return Collections.unmodifiableMap(config);
+    }
+
+    public List<String> getAllowedHosts() {
+        if (allowedHosts == null || allowedHosts.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableList(allowedHosts);
     }
 }

--- a/java/src/main/java/org/extism/sdk/manifest/ManifestHttpRequest.java
+++ b/java/src/main/java/org/extism/sdk/manifest/ManifestHttpRequest.java
@@ -2,9 +2,6 @@ package org.extism.sdk.manifest;
 
 import java.util.Map;
 
-public class ManifestHttpRequest {
-    public String url;
-    public Map<String, String> header;
-    public String method;
+public record ManifestHttpRequest(String url, Map<String, String> header, String method) {
 }
 

--- a/java/src/main/java/org/extism/sdk/manifest/ManifestMemory.java
+++ b/java/src/main/java/org/extism/sdk/manifest/ManifestMemory.java
@@ -1,5 +1,4 @@
 package org.extism.sdk.manifest;
 
-public class ManifestMemory {
-    public int max;
+public record ManifestMemory (int max){
 }

--- a/java/src/main/java/org/extism/sdk/manifest/ManifestWasm.java
+++ b/java/src/main/java/org/extism/sdk/manifest/ManifestWasm.java
@@ -1,4 +1,0 @@
-package org.extism.sdk.manifest;
-
-public abstract class ManifestWasm {
-}

--- a/java/src/main/java/org/extism/sdk/manifest/ManifestWasmData.java
+++ b/java/src/main/java/org/extism/sdk/manifest/ManifestWasmData.java
@@ -1,7 +1,0 @@
-package org.extism.sdk.manifest;
-
-public class ManifestWasmData extends ManifestWasm {
-    public byte[] data;
-    public String name;
-    public String hash;
-}

--- a/java/src/main/java/org/extism/sdk/manifest/ManifestWasmUrl.java
+++ b/java/src/main/java/org/extism/sdk/manifest/ManifestWasmUrl.java
@@ -1,8 +1,0 @@
-package org.extism.sdk.manifest;
-
-public class ManifestWasmUrl extends ManifestWasm {
-    public String path;
-    public String name;
-    public String hash;
-}
-

--- a/java/src/main/java/org/extism/sdk/support/JsonSerializer.java
+++ b/java/src/main/java/org/extism/sdk/support/JsonSerializer.java
@@ -10,7 +10,11 @@ public class JsonSerializer {
     private static final Gson GSON;
 
     static {
-        GSON = new GsonBuilder().disableHtmlEscaping().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).setPrettyPrinting().create();
+        GSON = new GsonBuilder() //
+                .disableHtmlEscaping() //
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES) //
+                .setPrettyPrinting() //
+                .create();
     }
 
     public static String toJson(Manifest manifest) {

--- a/java/src/main/java/org/extism/sdk/support/JsonSerializer.java
+++ b/java/src/main/java/org/extism/sdk/support/JsonSerializer.java
@@ -1,0 +1,19 @@
+package org.extism.sdk.support;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.extism.sdk.manifest.Manifest;
+
+public class JsonSerializer {
+
+    private static final Gson GSON;
+
+    static {
+        GSON = new GsonBuilder().disableHtmlEscaping().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).setPrettyPrinting().create();
+    }
+
+    public static String toJson(Manifest manifest) {
+        return GSON.toJson(manifest);
+    }
+}

--- a/java/src/main/java/org/extism/sdk/wasm/ByteArrayWasmSource.java
+++ b/java/src/main/java/org/extism/sdk/wasm/ByteArrayWasmSource.java
@@ -1,0 +1,11 @@
+package org.extism.sdk.wasm;
+
+/**
+ * WASM Source represented by raw bytes.
+ *
+ * @param name
+ * @param data the byte array representing the WASM code
+ * @param hash
+ */
+public record ByteArrayWasmSource(String name, byte[] data, String hash) implements WasmSource {
+}

--- a/java/src/main/java/org/extism/sdk/wasm/FileBasedWasmSource.java
+++ b/java/src/main/java/org/extism/sdk/wasm/FileBasedWasmSource.java
@@ -1,0 +1,12 @@
+package org.extism.sdk.wasm;
+
+/**
+ * A file based Wasm Source.
+ *
+ * @param name
+ * @param path
+ * @param hash
+ */
+public record FileBasedWasmSource(String name, String path, String hash) implements WasmSource {
+}
+

--- a/java/src/main/java/org/extism/sdk/wasm/WasmSource.java
+++ b/java/src/main/java/org/extism/sdk/wasm/WasmSource.java
@@ -1,0 +1,9 @@
+package org.extism.sdk.wasm;
+
+/**
+ * A named WASM source.
+ */
+public interface WasmSource {
+
+    String name();
+}

--- a/java/src/test/java/org/extism/sdk/ExtismTest.java
+++ b/java/src/test/java/org/extism/sdk/ExtismTest.java
@@ -1,47 +1,36 @@
 package org.extism.sdk;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-
 import org.extism.sdk.manifest.Manifest;
-import org.extism.sdk.manifest.ManifestWasm;
-import org.extism.sdk.manifest.ManifestWasmData;
-import org.extism.sdk.manifest.ManifestWasmUrl;
+import org.extism.sdk.wasm.FileBasedWasmSource;
+import org.junit.jupiter.api.Test;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import java.nio.file.Paths;
+import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class ExtismTest extends TestCase {
-    public ExtismTest(String testName) {
-        super(testName);
+public class ExtismTest {
+
+    @Test
+    public void shouldInvokeNamedFunction() {
+
+        var wasmFile = Paths.get("src", "test", "resources", "code.wasm").toFile();
+        try (var ctx = new Context()) {
+            var wasmSource = new FileBasedWasmSource(wasmFile.getName(), wasmFile.getAbsolutePath(), null);
+            var manifest = new Manifest(List.of(wasmSource));
+
+            try (var plugin = ctx.newPlugin(manifest, false)) {
+                var input = "Hello World";
+                var functionName = "count_vowels";
+                var output = plugin.call(functionName, input);
+                assertThat(output).isEqualTo("{\"count\": 3}");
+            }
+        }
     }
 
-    public static Test suite() {
-        return new TestSuite( ExtismTest.class );
-    }
-
-    public void testApp() {
-        Path resourceDirectory = Paths.get("src", "test", "resources", "code.wasm");
-        String absolutePath = resourceDirectory.toFile().getAbsolutePath();
-        Context ctx = new Context();
-        Manifest manifest = new Manifest();
-        manifest.wasm = new ArrayList<ManifestWasm>();
-        ManifestWasmUrl wasmData = new ManifestWasmUrl();
-        System.out.println(absolutePath);
-        wasmData.path = absolutePath;
-        manifest.wasm.add(wasmData);
-        Plugin plugin = ctx.newPlugin(manifest, false);
-        System.out.print(plugin.getIndex());
-
-        byte[] b = plugin.call("count_vowels", "Hello World".getBytes());
-        String output =new String(b, StandardCharsets.UTF_8);
-
-        this.assertEquals("{\"count\": 3}", output);
+    @Test
+    public void shouldReturnVersionString() {
+        var version = LibExtism.INSTANCE.extism_version();
+        assertThat(version).isNotNull();
     }
 }

--- a/java/src/test/java/org/extism/sdk/ExtismTest.java
+++ b/java/src/test/java/org/extism/sdk/ExtismTest.java
@@ -30,7 +30,9 @@ public class ExtismTest {
 
     @Test
     public void shouldReturnVersionString() {
-        var version = LibExtism.INSTANCE.extism_version();
-        assertThat(version).isNotNull();
+        try (var ctx = new Context()) {
+            var version = ctx.getVersion();
+            assertThat(version).isNotNull();
+        }
     }
 }


### PR DESCRIPTION
- Refactor Plugin
- Make `Plugin` and `Context`  `AutoClosable` to automatically free resources in TWR blocks
- Add missing javadoc
- Upgrade to Junit 5
- Reorganize packages
- Use more meaningful names
- Introduce `ExtismException`
- Make JSON serialization pluggable
- Lower required java version to Java 17

Improves #117