### PR TITLE
feat: add `allowed_paths` to specify preopened directories in WASI

### DIFF
--- a/manifest/schema.json
+++ b/manifest/schema.json
@@ -13,6 +13,16 @@
         "type": "string"
       }
     },
+    "allowed_paths": {
+      "default": null,
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "config": {
       "default": {},
       "type": "object",

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -173,8 +173,8 @@ impl Manifest {
         }
     }
 
-    /// Disable HTTP requests to all hosts
-    pub fn disable_all_hosts(mut self) -> Self {
+    /// Disallow HTTP requests to all hosts
+    pub fn disallow_all_hosts(mut self) -> Self {
         self.allowed_hosts = Some(vec![]);
         self
     }

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -179,6 +179,12 @@ impl Manifest {
         self
     }
 
+    /// Set memory options
+    pub fn with_memory_options(mut self, memory: MemoryOptions) -> Self {
+        self.memory = memory;
+        self
+    }
+
     /// Add a hostname to `allowed_hosts`
     pub fn with_allowed_host(mut self, host: impl Into<String>) -> Self {
         match &mut self.allowed_hosts {
@@ -188,6 +194,12 @@ impl Manifest {
             None => self.allowed_hosts = Some(vec![host.into()]),
         }
 
+        self
+    }
+
+    /// Set `allowed_hosts`
+    pub fn with_allowed_hosts(mut self, hosts: impl Iterator<Item = String>) -> Self {
+        self.allowed_hosts = Some(hosts.collect());
         self
     }
 
@@ -206,6 +218,18 @@ impl Manifest {
             }
         }
 
+        self
+    }
+
+    /// Set `allowed_paths`
+    pub fn with_allowed_paths(mut self, paths: impl Iterator<Item = (PathBuf, PathBuf)>) -> Self {
+        self.allowed_paths = Some(paths.collect());
+        self
+    }
+
+    /// Set `config`
+    pub fn with_config(mut self, c: impl Iterator<Item = (String, String)>) -> Self {
+        self.config = c.collect();
         self
     }
 }

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -172,24 +172,26 @@ impl Manifest {
             ..Default::default()
         }
     }
-}
 
-mod base64 {
-    use serde::{Deserialize, Serialize};
-    use serde::{Deserializer, Serializer};
-
-    pub fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
-        let base64 = base64::encode(v);
-        String::serialize(&base64, s)
+    /// Disable HTTP requests to all hosts
+    pub fn disable_all_hosts(mut self) -> Self {
+        self.allowed_hosts = Some(vec![]);
+        self
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
-        let base64 = String::deserialize(d)?;
-        base64::decode(base64.as_bytes()).map_err(serde::de::Error::custom)
-    }
-}
+    /// Add a hostname to `allowed_hosts`
+    pub fn with_allowed_host(mut self, host: impl Into<String>) -> Self {
+        match &mut self.allowed_hosts {
+            Some(h) => {
+                h.push(host.into());
+            }
+            None => self.allowed_hosts = Some(vec![host.into()]),
+        }
 
-impl Manifest {
+        self
+    }
+
+    /// Add a path to `allowed_paths`
     pub fn with_allowed_path(mut self, src: impl AsRef<Path>, dest: impl AsRef<Path>) -> Self {
         let src = src.as_ref().to_path_buf();
         let dest = dest.as_ref().to_path_buf();
@@ -205,5 +207,20 @@ impl Manifest {
         }
 
         self
+    }
+}
+
+mod base64 {
+    use serde::{Deserialize, Serialize};
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
+        let base64 = base64::encode(v);
+        String::serialize(&base64, s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+        let base64 = String::deserialize(d)?;
+        base64::decode(base64.as_bytes()).map_err(serde::de::Error::custom)
     }
 }

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -160,6 +160,8 @@ pub struct Manifest {
     pub config: BTreeMap<String, String>,
     #[serde(default)]
     pub allowed_hosts: Option<Vec<String>>,
+    #[serde(default)]
+    pub allowed_paths: Option<BTreeMap<String, String>>,
 }
 
 impl Manifest {

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -40,6 +40,13 @@ impl Internal {
                 ctx = ctx.env(k, v)?;
             }
 
+            if let Some(a) = &manifest.as_ref().allowed_paths {
+                for (k, v) in a.iter() {
+                    let d = wasmtime_wasi::Dir::from_std_file(std::fs::File::open(k)?);
+                    ctx = ctx.preopened_dir(d, v)?;
+                }
+            }
+
             #[cfg(feature = "nn")]
             let nn = wasmtime_wasi_nn::WasiNnCtx::new()?;
 


### PR DESCRIPTION
Adds ability to make local files available to plugins. Using the Rust SDK:

```rust
let wasm = include_bytes!("code.wasm");
let mut context = Context::new();
let manifest = Manifest::new(vec![Wasm::data(wasm)]).with_allowed_path("/path/on/disk", "/plugin/path");
let plugin = Plugin::new_with_manifest(&mut context, &manifest, false)?;
...
```
 