### PR TITLE
feat: Add ability to register host functions with the runtime from the Rust SDK

### DIFF
--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -166,9 +166,9 @@ pub struct Manifest {
 
 impl Manifest {
     /// Create a new manifest
-    pub fn new(wasm: impl Into<Vec<Wasm>>) -> Manifest {
+    pub fn new(wasm: impl IntoIterator<Item = impl Into<Wasm>>) -> Manifest {
         Manifest {
-            wasm: wasm.into(),
+            wasm: wasm.into_iter().map(|x| x.into()).collect(),
             ..Default::default()
         }
     }

--- a/runtime/src/context.rs
+++ b/runtime/src/context.rs
@@ -16,53 +16,6 @@ pub struct Context {
 
 const START_REUSING_IDS: usize = 25;
 
-pub struct Function(
-    pub(crate) String,
-    pub(crate) wasmtime::FuncType,
-    pub(crate)  Box<
-        dyn Fn(
-                wasmtime::Caller<Internal>,
-                &[wasmtime::Val],
-                &mut [wasmtime::Val],
-            ) -> Result<(), Error>
-            + Sync
-            + Send,
-    >,
-);
-
-impl Function {
-    pub fn new<F>(
-        name: impl Into<String>,
-        returns: impl IntoIterator<Item = wasmtime::ValType>,
-        args: impl IntoIterator<Item = wasmtime::ValType>,
-        f: F,
-    ) -> Function
-    where
-        F: 'static
-            + Fn(
-                wasmtime::Caller<Internal>,
-                &[wasmtime::Val],
-                &mut [wasmtime::Val],
-            ) -> Result<(), Error>
-            + Sync
-            + Send,
-    {
-        Function(
-            name.into(),
-            wasmtime::FuncType::new(returns, args),
-            Box::new(f),
-        )
-    }
-
-    pub fn name(&self) -> &str {
-        &self.0
-    }
-
-    pub fn ty(&self) -> &wasmtime::FuncType {
-        &self.1
-    }
-}
-
 impl Context {
     /// Create a new context
     pub fn new() -> Context {

--- a/runtime/src/context.rs
+++ b/runtime/src/context.rs
@@ -31,7 +31,12 @@ pub struct Function(
 );
 
 impl Function {
-    pub fn new<F>(name: impl Into<String>, t: wasmtime::FuncType, f: F) -> Function
+    pub fn new<F>(
+        name: impl Into<String>,
+        returns: impl IntoIterator<Item = wasmtime::ValType>,
+        args: impl IntoIterator<Item = wasmtime::ValType>,
+        f: F,
+    ) -> Function
     where
         F: 'static
             + Fn(
@@ -42,7 +47,11 @@ impl Function {
             + Sync
             + Send,
     {
-        Function(name.into(), t, Box::new(f))
+        Function(
+            name.into(),
+            wasmtime::FuncType::new(returns, args),
+            Box::new(f),
+        )
     }
 
     pub fn name(&self) -> &str {

--- a/runtime/src/function.rs
+++ b/runtime/src/function.rs
@@ -1,0 +1,102 @@
+use crate::{Error, Internal};
+
+/// A list of all possible value types in WebAssembly.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum ValType {
+    // NB: the ordering here is intended to match the ordering in
+    // `wasmtime_types::WasmType` to help improve codegen when converting.
+    /// Signed 32 bit integer.
+    I32,
+    /// Signed 64 bit integer.
+    I64,
+    /// Floating point 32 bit integer.
+    F32,
+    /// Floating point 64 bit integer.
+    F64,
+    /// A 128 bit number.
+    V128,
+    /// A reference to a Wasm function.
+    FuncRef,
+    /// A reference to opaque data in the Wasm instance.
+    ExternRef,
+}
+
+impl From<wasmtime::ValType> for ValType {
+    fn from(value: wasmtime::ValType) -> Self {
+        use wasmtime::ValType::*;
+        match value {
+            I32 => ValType::I32,
+            I64 => ValType::I64,
+            F32 => ValType::F32,
+            F64 => ValType::F64,
+            V128 => ValType::V128,
+            FuncRef => ValType::FuncRef,
+            ExternRef => ValType::ExternRef,
+        }
+    }
+}
+
+impl From<ValType> for wasmtime::ValType {
+    fn from(value: ValType) -> Self {
+        use ValType::*;
+        match value {
+            I32 => wasmtime::ValType::I32,
+            I64 => wasmtime::ValType::I64,
+            F32 => wasmtime::ValType::F32,
+            F64 => wasmtime::ValType::F64,
+            V128 => wasmtime::ValType::V128,
+            FuncRef => wasmtime::ValType::FuncRef,
+            ExternRef => wasmtime::ValType::ExternRef,
+        }
+    }
+}
+
+pub struct Function(
+    pub(crate) String,
+    pub(crate) wasmtime::FuncType,
+    pub(crate)  Box<
+        dyn Fn(
+                wasmtime::Caller<Internal>,
+                &[wasmtime::Val],
+                &mut [wasmtime::Val],
+            ) -> Result<(), Error>
+            + Sync
+            + Send,
+    >,
+);
+
+impl Function {
+    pub fn new<F>(
+        name: impl Into<String>,
+        returns: impl IntoIterator<Item = ValType>,
+        args: impl IntoIterator<Item = ValType>,
+        f: F,
+    ) -> Function
+    where
+        F: 'static
+            + Fn(
+                wasmtime::Caller<Internal>,
+                &[wasmtime::Val],
+                &mut [wasmtime::Val],
+            ) -> Result<(), Error>
+            + Sync
+            + Send,
+    {
+        Function(
+            name.into(),
+            wasmtime::FuncType::new(
+                returns.into_iter().map(wasmtime::ValType::from),
+                args.into_iter().map(wasmtime::ValType::from),
+            ),
+            Box::new(f),
+        )
+    }
+
+    pub fn name(&self) -> &str {
+        &self.0
+    }
+
+    pub fn ty(&self) -> &wasmtime::FuncType {
+        &self.1
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -9,7 +9,7 @@ mod plugin;
 mod plugin_ref;
 pub mod sdk;
 
-pub use context::Context;
+pub use context::{Context, Function};
 pub use manifest::Manifest;
 pub use memory::{MemoryBlock, PluginMemory};
 pub use plugin::{Internal, Plugin, Wasi};

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2,6 +2,7 @@ pub use anyhow::Error;
 pub(crate) use wasmtime::*;
 
 mod context;
+mod function;
 pub mod manifest;
 mod memory;
 pub(crate) mod pdk;
@@ -9,7 +10,8 @@ mod plugin;
 mod plugin_ref;
 pub mod sdk;
 
-pub use context::{Context, Function};
+pub use context::Context;
+pub use function::{Function, ValType};
 pub use manifest::Manifest;
 pub use memory::{MemoryBlock, PluginMemory};
 pub use plugin::{Internal, Plugin, Wasi};

--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -3,16 +3,17 @@ use crate::*;
 
 // This macro unwraps input arguments to prevent functions from panicking,
 // it should be used instead of `Val::unwrap_*` functions
+#[macro_export]
 macro_rules! args {
     ($input:expr, $index:expr, $ty:ident) => {
         match $input[$index].$ty() {
             Some(x) => x,
-            None => return Err(Error::msg("Invalid input type"))
+            None => return Err($crate::Error::msg("Invalid input type"))
         }
     };
     ($input:expr, $(($index:expr, $ty:ident)),*$(,)?) => {
         ($(
-            args!($input, $index, $ty),
+            $crate::args!($input, $index, $ty),
         )*)
     };
 }

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -155,7 +155,7 @@ impl Plugin {
             for import in module.imports() {
                 let module_name = import.module();
                 let name = import.name();
-                use ValType::*;
+                use wasmtime::ValType::*;
 
                 if module_name == EXPORT_MODULE_NAME {
                     define_funcs!(name,  {

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -96,7 +96,17 @@ const EXPORT_MODULE_NAME: &str = "env";
 impl Plugin {
     /// Create a new plugin from the given WASM code
     pub fn new(wasm: impl AsRef<[u8]>, with_wasi: bool) -> Result<Plugin, Error> {
+        Self::new_with_functions(wasm, [], with_wasi)
+    }
+
+    /// Create a new plugin from the given WASM code and imported functions
+    pub fn new_with_functions(
+        wasm: impl AsRef<[u8]>,
+        imports: impl IntoIterator<Item = Function>,
+        with_wasi: bool,
+    ) -> Result<Plugin, Error> {
         let engine = Engine::default();
+        let mut imports = imports.into_iter();
         let (manifest, modules) = Manifest::new(&engine, wasm.as_ref())?;
         let mut store = Store::new(&engine, Internal::new(&manifest, with_wasi)?);
         let memory = Memory::new(
@@ -171,6 +181,12 @@ impl Plugin {
                         log_debug(I64);
                         log_error(I64);
                     });
+
+                    for f in &mut imports {
+                        let name = f.name().to_string();
+                        let func = Func::new(&mut memory.store, f.ty().clone(), f.2);
+                        linker.define(EXPORT_MODULE_NAME, &name, func)?;
+                    }
                 }
             }
         }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,7 @@ description = "Extism Host SDK for Rust"
 [dependencies]
 extism-manifest = { version = "0.1.0", path = "../manifest" }
 extism-runtime = { version = "0.1.0", path = "../runtime"}
+wasmtime = { version = "3.0.0" }
 serde_json = "1"
 log = "0.4"
 thiserror = "1"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,6 @@ description = "Extism Host SDK for Rust"
 [dependencies]
 extism-manifest = { version = "0.1.0", path = "../manifest" }
 extism-runtime = { version = "0.1.0", path = "../runtime"}
-wasmtime = { version = "3.0.0" }
 serde_json = "1"
 log = "0.4"
 thiserror = "1"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,5 @@
 pub use extism_manifest::{self as manifest, Manifest};
-pub use extism_runtime::{sdk as bindings, Function};
+pub use extism_runtime::{sdk as bindings, Function, ValType};
 
 mod context;
 mod plugin;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3,9 +3,11 @@ pub use extism_runtime::{sdk as bindings, Function};
 
 mod context;
 mod plugin;
+mod plugin_builder;
 
 pub use context::Context;
 pub use plugin::Plugin;
+pub use plugin_builder::PluginBuilder;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -148,7 +150,7 @@ mod tests {
 
         std::thread::spawn(|| {
             let context = Context::new();
-            let mut plugin = Plugin::new(&context, WASM, false).unwrap();
+            let mut plugin = PluginBuilder::new_with_data(WASM).build(&context).unwrap();
             let output = plugin.call("count_vowels", "this is a test aaa").unwrap();
             std::io::stdout().write_all(output).unwrap();
         });

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -150,7 +150,9 @@ mod tests {
 
         std::thread::spawn(|| {
             let context = Context::new();
-            let mut plugin = PluginBuilder::new_with_data(WASM).build(&context).unwrap();
+            let mut plugin = PluginBuilder::new_with_module(WASM)
+                .build(&context)
+                .unwrap();
             let output = plugin.call("count_vowels", "this is a test aaa").unwrap();
             std::io::stdout().write_all(output).unwrap();
         });

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,5 @@
 pub use extism_manifest::{self as manifest, Manifest};
-pub use extism_runtime::sdk as bindings;
+pub use extism_runtime::{sdk as bindings, Function};
 
 mod context;
 mod plugin;

--- a/rust/src/plugin_builder.rs
+++ b/rust/src/plugin_builder.rs
@@ -1,0 +1,60 @@
+use crate::*;
+
+enum Source {
+    Manifest(Manifest),
+    Data(Vec<u8>),
+}
+
+/// PluginBuilder is used to configure and create `Plugin` instances
+pub struct PluginBuilder {
+    source: Source,
+    wasi: bool,
+    functions: Vec<Function>,
+}
+
+impl PluginBuilder {
+    /// Create a new `PluginBuilder` with the given WebAssembly module
+    pub fn new_with_module(data: impl Into<Vec<u8>>) -> Self {
+        PluginBuilder {
+            source: Source::Data(data.into()),
+            wasi: false,
+            functions: vec![],
+        }
+    }
+
+    /// Create a new `PluginBuilder` from a `Manifest`
+    pub fn new(manifest: Manifest) -> Self {
+        PluginBuilder {
+            source: Source::Manifest(manifest),
+            wasi: false,
+            functions: vec![],
+        }
+    }
+
+    /// Enables WASI if the argument is set to `true`
+    pub fn with_wasi(mut self, wasi: bool) -> Self {
+        self.wasi = wasi;
+        self
+    }
+
+    /// Add a single host function
+    pub fn with_function(mut self, f: Function) -> Self {
+        self.functions.push(f);
+        self
+    }
+
+    /// Add multiple host functions
+    pub fn with_functions(mut self, f: impl IntoIterator<Item = Function>) -> Self {
+        self.functions.extend(f);
+        self
+    }
+
+    pub fn build<'a>(self, context: &'a Context) -> Result<Plugin<'a>, Error> {
+        match self.source {
+            Source::Manifest(m) => {
+                Plugin::new_with_manifest_and_functions(context, &m, self.functions, self.wasi)
+            }
+            Source::Data(d) => Plugin::new_with_functions(context, &d, self.functions, self.wasi),
+        }
+    }
+}


### PR DESCRIPTION
- Adds the ability to initialize plugins with additional functions created by the host (only supported by the Rust SDK right now) 
- Adds `PluginBuilder` to the Rust SDK to make it easier to configure all the options

## Hello, world

The following example uses `println` from the host to print to stdout from inside the plugin.

Host:
```rust
use extism::*;

fn main() -> Result<(), Error> {
    let context = Context::new();
    let manifest = Manifest::new([std::path::PathBuf::from("code.wasm")]);
    let say_hello = Function::new("say_hello", [ValType::I64], [], |caller, input, _out| {
        let internal = caller.data();
        let r = internal.memory().get_str(input[0].unwrap_i64() as usize)?;
        println!("Hello, {r}!");
        Ok(())
    });
    let mut plugin = PluginBuilder::new(manifest)
        .with_function(say_hello)
        .with_wasi(true)
        .build(&context)?;
    plugin.call("test", b"world").unwrap();
    Ok(())
}
```

Plugin:
```rust
use extism_pdk::*;

extern "C" {
    fn say_hello(offs: u64);
}

#[plugin_fn]
pub fn test(input: String) -> FnResult<()> {
    let memory = Memory::from_bytes(&input);
    unsafe {
        say_hello(memory.offset);
    }
    Ok(())
}

```

