### PR TITLE
feat: Add `HttpRequest::timeout_ms` and `Manifest::http_timeout_ms` 

### DIFF
--- a/extism.go
+++ b/extism.go
@@ -58,6 +58,7 @@ type WasmUrl struct {
 	Headers map[string]string `json:"headers,omitempty"`
 	Name    string            `json:"name,omitempty"`
 	Method  string            `json:"method,omitempty"`
+	Timeout uint64            `json:"timeout_ms,omitempty"`
 }
 
 type Wasm interface{}
@@ -70,6 +71,7 @@ type Manifest struct {
 	Config       map[string]string `json:"config,omitempty"`
 	AllowedHosts []string          `json:"allowed_hosts,omitempty"`
 	AllowedPaths map[string]string `json:"allowed_paths,omitempty"`
+	Timeout      uint64            `json:"http_timeout_ms,omitempty"`
 }
 
 func makePointer(data []byte) unsafe.Pointer {

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -19,6 +19,8 @@ pub struct HttpRequest {
     #[serde(alias = "header")]
     pub headers: std::collections::BTreeMap<String, String>,
     pub method: Option<String>,
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
 }
 
 impl HttpRequest {
@@ -27,6 +29,7 @@ impl HttpRequest {
             url: url.into(),
             headers: Default::default(),
             method: None,
+            timeout_ms: None,
         }
     }
 
@@ -37,6 +40,11 @@ impl HttpRequest {
 
     pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> HttpRequest {
         self.headers.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn with_timeout(mut self, timeout: std::time::Duration) -> HttpRequest {
+        self.timeout_ms = Some(timeout.as_millis() as u64);
         self
     }
 }
@@ -162,6 +170,8 @@ pub struct Manifest {
     pub allowed_hosts: Option<Vec<String>>,
     #[serde(default)]
     pub allowed_paths: Option<BTreeMap<PathBuf, PathBuf>>,
+    #[serde(default)]
+    pub http_timeout_ms: Option<u64>,
 }
 
 impl Manifest {
@@ -230,6 +240,12 @@ impl Manifest {
     /// Set `config`
     pub fn with_config(mut self, c: impl Iterator<Item = (String, String)>) -> Self {
         self.config = c.collect();
+        self
+    }
+
+    /// Set global timeout for `extism_http_request`
+    pub fn with_http_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.http_timeout_ms = Some(timeout.as_millis() as u64);
         self
     }
 }

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -170,6 +170,7 @@ export type Manifest = {
   config?: PluginConfig;
   allowed_hosts?: Array<string>;
   allowed_paths?: Record<string, string>;
+  http_timeout_ms?: number;
 };
 
 /**

--- a/ocaml/lib/extism.ml
+++ b/ocaml/lib/extism.ml
@@ -141,6 +141,7 @@ module Manifest = struct
   type wasm_url = {
     url : string;
     headers : dict option; [@yojson.option]
+    timeout_ms: int option; [@yojson.option]
     name : string option; [@yojson.option]
     meth : string option; [@yojson.option] [@key "method"]
     hash : string option; [@yojson.option]
@@ -165,17 +166,18 @@ module Manifest = struct
     config : config option; [@yojson.option]
     allowed_hosts : string list option; [@yojson.option]
     allowed_paths : dict option; [@yojson.option]
+    http_timeout_ms : int option; [@yojson.option]
   }
   [@@deriving yojson]
 
   let file ?name ?hash path = File { path; name; hash }
   let data ?name ?hash data = Data { data; name; hash }
 
-  let url ?headers ?name ?meth ?hash url =
-    Url { headers; name; meth; hash; url }
+  let url ?headers ?name ?meth ?hash ?timeout_ms url =
+    Url { headers; name; meth; hash; url; timeout_ms }
 
-  let v ?config ?memory ?allowed_hosts ?allowed_paths wasm =
-    { config; wasm; memory; allowed_hosts; allowed_paths }
+  let v ?config ?memory ?allowed_hosts ?allowed_paths ?http_timeout_ms wasm =
+    { config; wasm; memory; allowed_hosts; allowed_paths; http_timeout_ms }
 
   let json t = yojson_of_t t |> Yojson.Safe.to_string
   let with_config t config = { t with config = Some config }

--- a/ocaml/lib/extism.mli
+++ b/ocaml/lib/extism.mli
@@ -24,6 +24,7 @@ module Manifest : sig
   type wasm_url = {
     url : string;
     headers : dict option; [@yojson.option]
+    timeout_ms: int option; [@yojson.option]
     name : string option; [@yojson.option]
     meth : string option; [@yojson.option] [@key "method"]
     hash : string option; [@yojson.option]
@@ -37,6 +38,7 @@ module Manifest : sig
     config : config option;
     allowed_hosts : string list option;
     allowed_paths : dict option;
+    http_timeout_ms: int option;
   }
 
   val file : ?name:string -> ?hash:string -> string -> wasm
@@ -47,6 +49,7 @@ module Manifest : sig
     ?name:string ->
     ?meth:string ->
     ?hash:string ->
+    ?timeout_ms:int ->
     string ->
     wasm
 
@@ -55,6 +58,7 @@ module Manifest : sig
     ?memory:memory ->
     ?allowed_hosts:string list ->
     ?allowed_paths:dict ->
+    ?http_timeout_ms:int ->
     wasm list ->
     t
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,16 +21,16 @@ log = "0.4"
 log4rs = "1.1"
 url = "2"
 glob = "0.3"
-ureq = {version = "2.5", optional=true}
 extism-manifest = { version = "0.1.0", path = "../manifest" }
 pretty-hex = { version = "0.3" }
+reqwest = {version = "0.11", features = ["blocking"], optional=true}
 
 [features]
 default = ["http", "register-http", "register-filesystem"]
 nn = ["wasmtime-wasi-nn"]
-register-http = ["ureq"] # enables wasm to be downloaded using http
-register-filesystem = [] # enables wasm to be loaded from disk
-http = ["ureq"]          # enables extism_http_request
+register-http = ["reqwest"] # enables wasm to be downloaded using http
+register-filesystem = []    # enables wasm to be loaded from disk
+http = ["reqwest"]          # enables extism_http_request
 
 [build-dependencies]
 cbindgen = "0.24"

--- a/runtime/src/manifest.rs
+++ b/runtime/src/manifest.rs
@@ -143,7 +143,7 @@ fn to_module(engine: &Engine, wasm: &extism_manifest::Wasm) -> Result<(String, M
                     req = req.set(k, v);
                 }
 
-                req = req.timeout(std::time::Duration::from_micros(
+                req = req.timeout(std::time::Duration::from_millis(
                     timeout_ms.unwrap_or(30000),
                 ));
 

--- a/runtime/src/manifest.rs
+++ b/runtime/src/manifest.rs
@@ -100,6 +100,7 @@ fn to_module(engine: &Engine, wasm: &extism_manifest::Wasm) -> Result<(String, M
                     url,
                     headers,
                     method,
+                    timeout_ms,
                 },
             meta,
         } => {
@@ -141,6 +142,10 @@ fn to_module(engine: &Engine, wasm: &extism_manifest::Wasm) -> Result<(String, M
                 for (k, v) in headers.iter() {
                     req = req.set(k, v);
                 }
+
+                req = req.timeout(std::time::Duration::from_micros(
+                    timeout_ms.unwrap_or(30000),
+                ));
 
                 // Fetch WASM code
                 let mut r = req.call()?.into_reader();

--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -343,7 +343,7 @@ pub(crate) fn http_request(
         let global_timeout = data.plugin().manifest.as_ref().http_timeout_ms;
         let req_timeout = req.timeout_ms;
 
-        r = r.timeout(std::time::Duration::from_micros(
+        r = r.timeout(std::time::Duration::from_millis(
             match (global_timeout, req_timeout) {
                 (Some(g), None) => g,
                 (None, Some(r)) => r,


### PR DESCRIPTION
Closes #151 

- Adds ability to configure timeout for `extism_http_request`
- Sets default timeout to 30s, but this can be overridden still
- Updates SDKs to support the new fields