### PR TITLE
fix: use timeouts for language-specific runtime initialization/finalization calls

### DIFF
--- a/runtime/src/context.rs
+++ b/runtime/src/context.rs
@@ -37,6 +37,7 @@ impl Context {
     /// Create a new context
     pub fn new() -> Context {
         let timer = &mut *Self::timer();
+
         let tx = match timer {
             None => Timer::init(timer),
             Some(t) => t.tx.clone(),


### PR DESCRIPTION
After adding the timer code plugins written in Haskell fail with a timeout when trying to call `hs_init` - this PR fixes the runtime initialization and updates those functions to respect the configured timeout.