### PR TITLE
feat: WASI support for browser runtime

### DIFF
--- a/browser/Makefile
+++ b/browser/Makefile
@@ -3,13 +3,16 @@
 prepare:
 	npm install
 
+build:
+	npm run build
+
 test: prepare
 	npm run test
 
 clean:
 	echo "No clean implemented"
 
-publish: clean prepare
+publish: clean prepare build
 	npm publish
 
 format:

--- a/browser/build.js
+++ b/browser/build.js
@@ -6,7 +6,7 @@ const sharedConfig = {
     bundle: true,
     minify: false,
     drop: [], // preseve debugger statements
-    external: Object.keys(dependencies || {}).concat(Object.keys(peerDependencies || {})),
+    external: Object.keys(peerDependencies || {}),
 };
 
 build({

--- a/browser/index.html
+++ b/browser/index.html
@@ -104,7 +104,7 @@
 
         async loadFunctions(url) {
             let plugin = await this.extismContext.newPlugin({ "wasm": [ { "path": url } ] }) 
-            let functions = await plugin.getExportedFunctions()
+            let functions = Object.keys(await plugin.getExports())
             console.log("funcs ", functions)
             this.setState({functions})
         }

--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@extism/runtime-browser",
       "version": "0.1.0",
       "license": "BSD-3-Clause",
+      "dependencies": {
+        "@bjorn3/browser_wasi_shim": "^0.1.0"
+      },
       "devDependencies": {
         "@types/jest": "^29.2.2",
         "esbuild": "^0.15.13",
@@ -544,6 +547,11 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@bjorn3/browser_wasi_shim": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.1.0.tgz",
+      "integrity": "sha512-Y40ya5ONBFZQNg6DJAbB5AC/76k+auU03se3h9bnLsUDzn4OQfjXw8mbUcWiz0uX7HgObC2S/486Oa0d+fjSqA=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.13",
@@ -5926,6 +5934,11 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@bjorn3/browser_wasi_shim": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.1.0.tgz",
+      "integrity": "sha512-Y40ya5ONBFZQNg6DJAbB5AC/76k+auU03se3h9bnLsUDzn4OQfjXw8mbUcWiz0uX7HgObC2S/486Oa0d+fjSqA=="
     },
     "@esbuild/android-arm": {
       "version": "0.15.13",

--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@bjorn3/browser_wasi_shim": "^0.1.0"
+        "@bjorn3/browser_wasi_shim": "^0.2.0"
       },
       "devDependencies": {
         "@types/jest": "^29.2.2",
@@ -549,9 +549,9 @@
       "dev": true
     },
     "node_modules/@bjorn3/browser_wasi_shim": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.1.0.tgz",
-      "integrity": "sha512-Y40ya5ONBFZQNg6DJAbB5AC/76k+auU03se3h9bnLsUDzn4OQfjXw8mbUcWiz0uX7HgObC2S/486Oa0d+fjSqA=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.0.tgz",
+      "integrity": "sha512-kFSqC9hIEivGIWcODhnyhdcbuK9Prj/FJHjb+sa/rcLFlWyFvEtJ/mhM+UG8hZCJkVZtOgSLTRV0OV3J1jjBVA=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.13",
@@ -5936,9 +5936,9 @@
       "dev": true
     },
     "@bjorn3/browser_wasi_shim": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.1.0.tgz",
-      "integrity": "sha512-Y40ya5ONBFZQNg6DJAbB5AC/76k+auU03se3h9bnLsUDzn4OQfjXw8mbUcWiz0uX7HgObC2S/486Oa0d+fjSqA=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.0.tgz",
+      "integrity": "sha512-kFSqC9hIEivGIWcODhnyhdcbuK9Prj/FJHjb+sa/rcLFlWyFvEtJ/mhM+UG8hZCJkVZtOgSLTRV0OV3J1jjBVA=="
     },
     "@esbuild/android-arm": {
       "version": "0.15.13",

--- a/browser/package.json
+++ b/browser/package.json
@@ -30,5 +30,8 @@
     "tslint-config-prettier": "^1.18.0",
     "typedoc": "^0.23.20",
     "typescript": "^4.8.4"
+  },
+  "dependencies": {
+    "@bjorn3/browser_wasi_shim": "^0.1.0"
   }
 }

--- a/browser/package.json
+++ b/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extism/runtime-browser",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Extism runtime in the browser",
   "scripts": {
     "build": "node build.js && tsc --emitDeclarationOnly --outDir dist",

--- a/browser/package.json
+++ b/browser/package.json
@@ -32,6 +32,6 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@bjorn3/browser_wasi_shim": "^0.1.0"
+    "@bjorn3/browser_wasi_shim": "^0.2.0"
   }
 }

--- a/browser/src/plugin.ts
+++ b/browser/src/plugin.ts
@@ -82,6 +82,9 @@ export default class ExtismPlugin {
       env: environment
     };
     this.module = await WebAssembly.instantiate(this.moduleData, env);
+    if (this.module.instance.exports._start) {
+      wasi.start(this.module.instance);
+    }
     return this.module;
   }
 

--- a/browser/src/plugin.ts
+++ b/browser/src/plugin.ts
@@ -1,9 +1,7 @@
 import Allocator from './allocator';
 import { PluginConfig } from './manifest';
-//@ts-ignore
-import WASI from "@bjorn3/browser_wasi_shim/src/wasi";
-//@ts-ignore
-import { File } from "@bjorn3/browser_wasi_shim/src/fs_core";
+//@ts-ignore TODO add types to this library
+import { WASI, File } from "@bjorn3/browser_wasi_shim";
 
 export default class ExtismPlugin {
   moduleData: ArrayBuffer;
@@ -71,10 +69,6 @@ export default class ExtismPlugin {
         new File([]), // stdin
         new File([]), // stdout
         new File([]), // stderr
-        // new PreopenDirectory(".", {
-        //     "example.c": new File(new TextEncoder("utf-8").encode(`#include "a"`)),
-        //     "hello.rs": new File(new TextEncoder("utf-8").encode(`fn main() { println!("Hello World!"); }`)),
-        // }),
     ];
     let wasi = new WASI(args, envVars, fds);
     let env = {
@@ -82,9 +76,6 @@ export default class ExtismPlugin {
       env: environment
     };
     this.module = await WebAssembly.instantiate(this.moduleData, env);
-    if (this.module.instance.exports._start) {
-      wasi.start(this.module.instance);
-    }
     return this.module;
   }
 

--- a/browser/tsconfig.json
+++ b/browser/tsconfig.json
@@ -6,7 +6,8 @@
       "forceConsistentCasingInFileNames": true,
       "declaration": true,
       "strict": true,                   
-      "skipLibCheck": true                  
+      "skipLibCheck": true,
+      "allowJs": true
     },
     "exclude": ["node_modules", "dist", "**/*.test.ts"]
   }


### PR DESCRIPTION
closes #160

Goal is not to expose all the WASI functionality, but to just write minimum code to allow PDK targets that require WASI (e.g. tinygo compiled plugins) to work in the browser. We can follow up with allowing the user more control over the WASI environment.