### PR TITLE
feat(rust-sdk): `Context` collection

### DIFF
--- a/rust/src/context.rs
+++ b/rust/src/context.rs
@@ -1,7 +1,7 @@
 use extism_runtime::PluginIndex;
 
 use crate::{
-    plugin_builder::{PluginScheme, Source},
+    plugin_builder::{ Source},
     *,
 };
 
@@ -27,12 +27,17 @@ impl Context {
         todo!()
     }
 
-    pub fn insert(&self, scheme: PluginScheme) -> Result<Plugin, Error> {
-        match scheme.source {
+    pub fn insert(
+        &self,
+        source: Source,
+        functions: Vec<Function>,
+        wasi: bool,
+    ) -> Result<Plugin, Error> {
+        match source {
             Source::Manifest(m) => {
-                Plugin::new_with_manifest_and_functions(&self, &m, scheme.functions, scheme.wasi)
+                Plugin::new_with_manifest_and_functions(self, &m, functions, wasi)
             }
-            Source::Data(d) => Plugin::new_with_functions(&self, &d, scheme.functions, scheme.wasi),
+            Source::Data(d) => Plugin::new_with_functions(self, d, functions, wasi),
         }
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,7 +7,7 @@ mod plugin_builder;
 
 pub use context::Context;
 pub use plugin::Plugin;
-pub use plugin_builder::PluginBuilder;
+pub use plugin_builder::PluginSchemeBuilder;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -150,8 +150,9 @@ mod tests {
 
         std::thread::spawn(|| {
             let context = Context::new();
-            let mut plugin = PluginBuilder::new_with_module(WASM)
-                .build(&context)
+            let scheme = PluginSchemeBuilder::new_with_module(WASM)
+                .build();
+            let mut plugin = context.insert(scheme)
                 .unwrap();
             let output = plugin.call("count_vowels", "this is a test aaa").unwrap();
             std::io::stdout().write_all(output).unwrap();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,7 +7,7 @@ mod plugin_builder;
 
 pub use context::Context;
 pub use plugin::Plugin;
-pub use plugin_builder::PluginSchemeBuilder;
+pub use plugin_builder::PluginBuilder;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -150,9 +150,8 @@ mod tests {
 
         std::thread::spawn(|| {
             let context = Context::new();
-            let scheme = PluginSchemeBuilder::new_with_module(WASM)
-                .build();
-            let mut plugin = context.insert(scheme)
+            let mut plugin = PluginBuilder::new_with_module(WASM)
+                .build(&context)
                 .unwrap();
             let output = plugin.call("count_vowels", "this is a test aaa").unwrap();
             std::io::stdout().write_all(output).unwrap();

--- a/rust/src/plugin.rs
+++ b/rust/src/plugin.rs
@@ -2,7 +2,7 @@ use crate::*;
 use std::collections::BTreeMap;
 
 pub struct Plugin<'a> {
-    id: extism_runtime::PluginIndex,
+    pub(crate) id: extism_runtime::PluginIndex,
     context: &'a Context,
 }
 
@@ -20,7 +20,7 @@ impl<'a> Plugin<'a> {
     }
 
     /// Create a new plugin from the given manifest
-    pub fn new_with_manifest(
+    pub(crate) fn new_with_manifest(
         ctx: &'a Context,
         manifest: &Manifest,
         wasi: bool,
@@ -30,7 +30,7 @@ impl<'a> Plugin<'a> {
     }
 
     /// Create a new plugin from the given manifest and import functions
-    pub fn new_with_manifest_and_functions(
+    pub(crate) fn new_with_manifest_and_functions(
         ctx: &'a Context,
         manifest: &Manifest,
         imports: impl IntoIterator<Item = extism_runtime::Function>,
@@ -41,7 +41,7 @@ impl<'a> Plugin<'a> {
     }
 
     /// Create a new plugin from a WASM module
-    pub fn new(ctx: &'a Context, data: impl AsRef<[u8]>, wasi: bool) -> Result<Plugin, Error> {
+    pub(crate) fn new(ctx: &'a Context, data: impl AsRef<[u8]>, wasi: bool) -> Result<Plugin, Error> {
         let plugin = ctx.lock().new_plugin(data, wasi);
 
         if plugin < 0 {
@@ -58,7 +58,7 @@ impl<'a> Plugin<'a> {
     }
 
     /// Create a new plugin from a WASM module with imported functions
-    pub fn new_with_functions(
+    pub(crate) fn new_with_functions(
         ctx: &'a Context,
         data: impl AsRef<[u8]>,
         imports: impl IntoIterator<Item = extism_runtime::Function>,
@@ -170,11 +170,5 @@ impl<'a> Plugin<'a> {
             let ptr = bindings::extism_plugin_output_data(&mut *self.context.lock(), self.id);
             Ok(std::slice::from_raw_parts(ptr, out_len as usize))
         }
-    }
-}
-
-impl<'a> Drop for Plugin<'a> {
-    fn drop(&mut self) {
-        unsafe { bindings::extism_plugin_free(&mut *self.context.lock(), self.id) }
     }
 }

--- a/rust/src/plugin_builder.rs
+++ b/rust/src/plugin_builder.rs
@@ -5,32 +5,26 @@ pub enum Source {
     Data(Vec<u8>),
 }
 
-pub struct PluginScheme {
-    pub(crate) source: Source,
-    pub(crate) wasi: bool,
-    pub(crate) functions: Vec<Function>,
-}
-
-/// PluginSchemeBuilder is used to configure and create `Plugin` instances
-pub struct PluginSchemeBuilder {
+/// PluginBuilder is used to configure and create `Plugin` instances
+pub struct PluginBuilder {
     source: Source,
     wasi: bool,
     functions: Vec<Function>,
 }
 
-impl PluginSchemeBuilder {
-    /// Create a new `PluginSchemeBuilder` with the given WebAssembly module
+impl PluginBuilder {
+    /// Create a new `PluginBuilder` with the given WebAssembly module
     pub fn new_with_module(data: impl Into<Vec<u8>>) -> Self {
-        PluginSchemeBuilder {
+        PluginBuilder {
             source: Source::Data(data.into()),
             wasi: false,
             functions: vec![],
         }
     }
 
-    /// Create a new `PluginSchemeBuilder` from a `Manifest`
+    /// Create a new `PluginBuilder` from a `Manifest`
     pub fn new(manifest: Manifest) -> Self {
-        PluginSchemeBuilder {
+        PluginBuilder {
             source: Source::Manifest(manifest),
             wasi: false,
             functions: vec![],
@@ -55,11 +49,7 @@ impl PluginSchemeBuilder {
         self
     }
 
-    pub fn build(self, ) -> PluginScheme {
-        PluginScheme {
-            source: self.source,
-            wasi: self.wasi,
-            functions: self.functions
-        }
+    pub fn build(self, context: &Context) -> Result<Plugin, Error> {
+        context.insert(self.source, self.functions, self.wasi)
     }
 }

--- a/rust/src/plugin_builder.rs
+++ b/rust/src/plugin_builder.rs
@@ -1,30 +1,36 @@
 use crate::*;
 
-enum Source {
+pub enum Source {
     Manifest(Manifest),
     Data(Vec<u8>),
 }
 
-/// PluginBuilder is used to configure and create `Plugin` instances
-pub struct PluginBuilder {
+pub struct PluginScheme {
+    pub(crate) source: Source,
+    pub(crate) wasi: bool,
+    pub(crate) functions: Vec<Function>,
+}
+
+/// PluginSchemeBuilder is used to configure and create `Plugin` instances
+pub struct PluginSchemeBuilder {
     source: Source,
     wasi: bool,
     functions: Vec<Function>,
 }
 
-impl PluginBuilder {
-    /// Create a new `PluginBuilder` with the given WebAssembly module
+impl PluginSchemeBuilder {
+    /// Create a new `PluginSchemeBuilder` with the given WebAssembly module
     pub fn new_with_module(data: impl Into<Vec<u8>>) -> Self {
-        PluginBuilder {
+        PluginSchemeBuilder {
             source: Source::Data(data.into()),
             wasi: false,
             functions: vec![],
         }
     }
 
-    /// Create a new `PluginBuilder` from a `Manifest`
+    /// Create a new `PluginSchemeBuilder` from a `Manifest`
     pub fn new(manifest: Manifest) -> Self {
-        PluginBuilder {
+        PluginSchemeBuilder {
             source: Source::Manifest(manifest),
             wasi: false,
             functions: vec![],
@@ -49,12 +55,11 @@ impl PluginBuilder {
         self
     }
 
-    pub fn build(self, context: &Context) -> Result<Plugin, Error> {
-        match self.source {
-            Source::Manifest(m) => {
-                Plugin::new_with_manifest_and_functions(context, &m, self.functions, self.wasi)
-            }
-            Source::Data(d) => Plugin::new_with_functions(context, &d, self.functions, self.wasi),
+    pub fn build(self, ) -> PluginScheme {
+        PluginScheme {
+            source: self.source,
+            wasi: self.wasi,
+            functions: self.functions
         }
     }
 }


### PR DESCRIPTION
## Example implementation of the idea proposed in #202.

The goal here is to treat `Context` as it is treated internally; a collection of plugins. This will allow users to store and call plugins whenever they want, without them being freed and without having to cache them again.  

A lot of the code doesn't make use of the libraries conventions, I threw it together as an example. Let me know what you think and if we should go ahead with implementing this.