### PR TITLE
fix(elixir-sdk): Release 0.2.0 is broken due to this local path dep

### DIFF
--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -4,7 +4,7 @@ defmodule Extism.MixProject do
   def project do
     [
       app: :extism,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/elixir/native/extism_nif/Cargo.toml
+++ b/elixir/native/extism_nif/Cargo.toml
@@ -11,5 +11,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.26.0"
-extism = { version = "0.2.0", path = "../../../rust" }
+extism = { version = "0.2.0" }
 log = "0.4"


### PR DESCRIPTION
https://github.com/extism/extism/commit/5c9aa4c90a83542c043c366ba7ebce50e81b3d65

This should work but it doesn't. Error message when including extism 0.2.0 locally:

```
Compiling 4 files (.ex)
error: failed to get `extism` as a dependency of package `extism_nif v0.1.0 (/private/tmp/extism_test/deps/extism/native/extism_nif)`

Caused by:
  failed to load source for dependency `extism`

Caused by:
  Unable to update /private/tmp/extism_test/deps/rust

Caused by:
  failed to read `/private/tmp/extism_test/deps/rust/Cargo.toml`

Caused by:
  No such file or directory (os error 2)

== Compilation error in file lib/extism/native.ex ==
** (RuntimeError) calling `cargo metadata` failed.

    (rustler 0.26.0) lib/rustler/compiler/config.ex:87: Rustler.Compiler.Config.metadata!/1
    (rustler 0.26.0) lib/rustler/compiler/config.ex:69: Rustler.Compiler.Config.build/1
    (rustler 0.26.0) lib/rustler/compiler.ex:9: Rustler.Compiler.compile_crate/2
    lib/extism/native.ex:6: (module)
could not compile dependency :extism, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile extism", update it with "mix deps.update extism" or clean it with "mix deps.clean extism"
```

