### PR TITLE
chore: Make memory traces clearer

### DIFF
--- a/runtime/src/memory.rs
+++ b/runtime/src/memory.rs
@@ -61,7 +61,7 @@ impl PluginMemory {
 
     /// Write byte to memory
     pub(crate) fn store_u8(&mut self, offs: usize, data: u8) -> Result<(), MemoryAccessError> {
-        trace!("store_u8: {data:x} at offset {offs}");
+        trace!("store_u8: offset={offs} data={data:#04x}");
         if offs >= self.size() {
             // This should raise MemoryAccessError
             let buf = &mut [0];
@@ -74,7 +74,7 @@ impl PluginMemory {
 
     /// Read byte from memory
     pub(crate) fn load_u8(&self, offs: usize) -> Result<u8, MemoryAccessError> {
-        trace!("load_u8: offset {offs}");
+        trace!("load_u8: offset={offs}");
         if offs >= self.size() {
             // This should raise MemoryAccessError
             let buf = &mut [0];
@@ -86,7 +86,7 @@ impl PluginMemory {
 
     /// Write u64 to memory
     pub(crate) fn store_u64(&mut self, offs: usize, data: u64) -> Result<(), Error> {
-        trace!("store_u64: {data:x} at offset {offs}");
+        trace!("store_u64: offset={offs} data={data:#18x}");
         let handle = MemoryBlock {
             offset: offs,
             length: 8,
@@ -97,7 +97,7 @@ impl PluginMemory {
 
     /// Read u64 from memory
     pub(crate) fn load_u64(&self, offs: usize) -> Result<u64, Error> {
-        trace!("load_u64: offset {offs}");
+        trace!("load_u64: offset={offs}");
         let mut buf = [0; 8];
         let handle = MemoryBlock {
             offset: offs,


### PR DESCRIPTION
If you look at the memory traces it's not really clear what the values are:

```
extism_runtime::memory TRACE 2023-01-23T10:05:16.918413-06:00 - store_u64: 656c626169726176 at offset 25
extism_runtime::memory TRACE 2023-01-23T10:05:16.918418-06:00 - store_u8: 20 at offset 33
extism_runtime::memory TRACE 2023-01-23T10:05:16.918423-06:00 - store_u8: 76 at offset 34
extism_runtime::memory TRACE 2023-01-23T10:05:16.918428-06:00 - store_u8: 61 at offset 35
extism_runtime::memory TRACE 2023-01-23T10:05:16.918433-06:00 - store_u8: 6c at offset 36
extism_runtime::memory TRACE 2023-01-23T10:05:16.918438-06:00 - store_u8: 75 at offset 37
extism_runtime::memory TRACE 2023-01-23T10:05:16.918443-06:00 - store_u8: 65 at offset 38
```

It's hard to tell that the value is hex and the offset is base10. This changes u8 values to the form `0x00` where there is always 2 digits and it will always use 16 digits for u64.