### PR TITLE
cleanup: fix opam files according to changes published to opam

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -21,12 +21,13 @@
  (description "Bindings to Extism, the universal plugin system")
  (depends 
   (ocaml (>= 4.14.1)) 
-  (dune (>= 3.2))
+  dune
+  (ctypes (>= 0.18.0))
   (ctypes-foreign (>= 0.18.0))
   (bigstringaf (>= 0.9.0))
-  (ppx_yojson_conv (>= 0.15.0))
+  (ppx_yojson_conv (>= v0.15.0))
   extism-manifest
-  (ppx_inline_test (>= 0.15.0))
+  (ppx_inline_test (>= v0.15.0))
   (cmdliner (>= 1.1.1))
  )
  (tags
@@ -38,9 +39,9 @@
  (description "Bindings to the Extism manifest format")
  (depends 
   (ocaml (>= 4.14.1)) 
-  (dune (>= 3.2))
-  (ppx_yojson_conv (>= 0.15.0))
-  (ppx_inline_test (>= 0.15.0))
+  dune
+  (ppx_yojson_conv (>= v0.15.0))
+  (ppx_inline_test (>= v0.15.0))
   (base64 (>= 3.5.0))
  )
  (tags

--- a/extism-manifest.opam
+++ b/extism-manifest.opam
@@ -11,9 +11,9 @@ doc: "https://github.com/extism/extism"
 bug-reports: "https://github.com/extism/extism/issues"
 depends: [
   "ocaml" {>= "4.14.1"}
-  "dune" {>= "3.2" & >= "3.2"}
-  "ppx_yojson_conv" {>= "0.15.0"}
-  "ppx_inline_test" {>= "0.15.0"}
+  "dune" {>= "3.2"}
+  "ppx_yojson_conv" {>= "v0.15.0"}
+  "ppx_inline_test" {>= "v0.15.0"}
   "base64" {>= "3.5.0"}
   "odoc" {with-doc}
 ]

--- a/extism.opam
+++ b/extism.opam
@@ -11,12 +11,13 @@ doc: "https://github.com/extism/extism"
 bug-reports: "https://github.com/extism/extism/issues"
 depends: [
   "ocaml" {>= "4.14.1"}
-  "dune" {>= "3.2" & >= "3.2"}
+  "dune" {>= "3.2"}
+  "ctypes" {>= "0.18.0"}
   "ctypes-foreign" {>= "0.18.0"}
   "bigstringaf" {>= "0.9.0"}
-  "ppx_yojson_conv" {>= "0.15.0"}
+  "ppx_yojson_conv" {>= "v0.15.0"}
   "extism-manifest"
-  "ppx_inline_test" {>= "0.15.0"}
+  "ppx_inline_test" {>= "v0.15.0"}
   "cmdliner" {>= "1.1.1"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
A few changes to the opam files based on the review from https://github.com/ocaml/opam-repository/pull/23018