### PR TITLE
chore: update wasmtime to 6.0, bump extism versions

### DIFF
--- a/elixir/native/extism_nif/Cargo.toml
+++ b/elixir/native/extism_nif/Cargo.toml
@@ -11,5 +11,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.27.0"
-extism = { version = "0.2.0" }
+extism = { version = "0.2.1", path = "../../../rust", package = "extism" }
 log = "0.4"

--- a/libextism/Cargo.toml
+++ b/libextism/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libextism"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["The Extism Authors", "oss@extism.org"]
 license = "BSD-3-Clause"

--- a/manifest/Cargo.toml
+++ b/manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extism-manifest"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["The Extism Authors", "oss@extism.org"]
 license = "BSD-3-Clause"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extism-runtime"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["The Extism Authors", "oss@extism.org"]
 license = "BSD-3-Clause"
@@ -9,9 +9,9 @@ repository = "https://github.com/extism/extism"
 description = "Extism runtime component"
 
 [dependencies]
-wasmtime = "4.0.0"
-wasmtime-wasi = "4.0.0"
-wasmtime-wasi-nn = {version = "4.0.0", optional=true}
+wasmtime = "5.0.0"
+wasmtime-wasi = "5.0.0"
+wasmtime-wasi-nn = {version = "5.0.0", optional=true}
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/extism/extism"
 description = "Extism runtime component"
 
 [dependencies]
-wasmtime = "5.0.0"
-wasmtime-wasi = "5.0.0"
-wasmtime-wasi-nn = {version = "5.0.0", optional=true}
+wasmtime = "6.0.0"
+wasmtime-wasi = "6.0.0"
+wasmtime-wasi-nn = {version = "6.0.0", optional=true}
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -144,7 +144,7 @@ impl Plugin {
                     concat!("extism_", stringify!($name)) => {
                         let t = FuncType::new([$($args),*], [$($($r),*)?]);
                         let f = Func::new(&mut memory.store, t, pdk::$name);
-                        linker.define(EXPORT_MODULE_NAME, concat!("extism_", stringify!($name)), Extern::Func(f))?;
+                        linker.define(&mut memory.store, EXPORT_MODULE_NAME, concat!("extism_", stringify!($name)), Extern::Func(f))?;
                         continue
                     }
                 )*
@@ -191,7 +191,7 @@ impl Plugin {
                         let func = Func::new(&mut memory.store, f.ty().clone(), unsafe {
                             &*std::sync::Arc::as_ptr(&f.f)
                         });
-                        linker.define(ns, &name, func)?;
+                        linker.define(&mut memory.store, ns, &name, func)?;
                     }
                 }
             }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extism"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["The Extism Authors", "oss@extism.org"]
 license = "BSD-3-Clause"
@@ -9,8 +9,8 @@ repository = "https://github.com/extism/extism"
 description = "Extism Host SDK for Rust"
 
 [dependencies]
-extism-manifest = { version = "0.2.0", path = "../manifest" }
-extism-runtime = { version = "0.2.0", path = "../runtime"}
+extism-manifest = { version = "0.2.1", path = "../manifest" }
+extism-runtime = { version = "0.2.1", path = "../runtime"}
 serde_json = "1"
 log = "0.4"
 anyhow = "1"


### PR DESCRIPTION
Unsure if now is the best time to do the `extism` crate version bumps, but I figured they'd need to happen at some point in the near future anyways. Happy to revert if there is any opposition. Also, I added back the local `path` property to the Elixir NIF crate manifest. I want to see if this breaks again in CI, or if we can leave it.  