### PR TITLE
fix: remove call to cleanup_timer at exit on windows

### DIFF
--- a/runtime/src/timer.rs
+++ b/runtime/src/timer.rs
@@ -20,6 +20,7 @@ pub(crate) struct Timer {
     pub thread: Option<std::thread::JoinHandle<()>>,
 }
 
+#[cfg(not(target_family = "windows"))]
 extern "C" fn cleanup_timer() {
     drop(Context::timer().take())
 }
@@ -90,6 +91,7 @@ impl Timer {
             tx: tx.clone(),
         });
 
+        #[cfg(not(target_family = "windows"))]
         unsafe {
             libc::atexit(cleanup_timer);
         }


### PR DESCRIPTION
Fixes #299