### PR TITLE
fix(browser): Fix browser runtime, publish as 0.2.7

### DIFF
--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@extism/runtime-browser",
-  "version": "0.2.2",
+  "version": "0.2.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@extism/runtime-browser",
-      "version": "0.2.2",
+      "version": "0.2.7",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@bjorn3/browser_wasi_shim": "^0.2.1"
+        "@bjorn3/browser_wasi_shim": "^0.2.7"
       },
       "devDependencies": {
         "@types/jest": "^29.2.2",
@@ -568,9 +568,9 @@
       "dev": true
     },
     "node_modules/@bjorn3/browser_wasi_shim": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.1.tgz",
-      "integrity": "sha512-QBI2VPoCksV+bN47v1edbFC0td1nXvEhK3i1oTrByKOnLG39RoxZR2KmLByR/6S+8ivAf2E4pWhqRRZsBWItyQ=="
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.7.tgz",
+      "integrity": "sha512-ONBGleCpaH5HC4MLLkUmLz69xA28HQIbvwsdA1WTMXvjyhOWXR7jVrC0DkYr/iRqmkNMBZtEVVZWm1L6ZAnJvw=="
     },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
@@ -8681,9 +8681,9 @@
       "dev": true
     },
     "@bjorn3/browser_wasi_shim": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.1.tgz",
-      "integrity": "sha512-QBI2VPoCksV+bN47v1edbFC0td1nXvEhK3i1oTrByKOnLG39RoxZR2KmLByR/6S+8ivAf2E4pWhqRRZsBWItyQ=="
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.7.tgz",
+      "integrity": "sha512-ONBGleCpaH5HC4MLLkUmLz69xA28HQIbvwsdA1WTMXvjyhOWXR7jVrC0DkYr/iRqmkNMBZtEVVZWm1L6ZAnJvw=="
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",

--- a/browser/package.json
+++ b/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extism/runtime-browser",
-  "version": "0.2.2",
+  "version": "0.2.7",
   "description": "Extism runtime in the browser",
   "scripts": {
     "build": "node build.js && tsc --emitDeclarationOnly --outDir dist",
@@ -34,6 +34,6 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@bjorn3/browser_wasi_shim": "^0.2.1"
+    "@bjorn3/browser_wasi_shim": "^0.2.7"
   }
 }


### PR DESCRIPTION
This upgrades the wasi shim and publishes new version of our runtime. Current published version is broken because it relies on a my git branch which has since been merged into the wasi shim.