### PR TITLE
feat: add EXTISM_PROFILE environment variable to configure profiling

### DIFF
--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -95,6 +95,17 @@ impl Internal {
 
 const EXPORT_MODULE_NAME: &str = "env";
 
+fn profiling_strategy() -> ProfilingStrategy {
+    match std::env::var("EXTISM_PROFILE").as_deref() {
+        Ok("perf") => ProfilingStrategy::PerfMap,
+        Ok(x) => {
+            log::warn!("Invalid value for EXTISM_PROFILE: {x}");
+            ProfilingStrategy::None
+        }
+        Err(_) => ProfilingStrategy::None,
+    }
+}
+
 impl Plugin {
     /// Create a new plugin from the given WASM code
     pub fn new<'a>(
@@ -105,7 +116,8 @@ impl Plugin {
         let engine = Engine::new(
             Config::new()
                 .epoch_interruption(true)
-                .debug_info(std::env::var("EXTISM_DEBUG").is_ok()),
+                .debug_info(std::env::var("EXTISM_DEBUG").is_ok())
+                .profiler(profiling_strategy()),
         )?;
         let mut imports = imports.into_iter();
         let (manifest, modules) = Manifest::new(&engine, wasm.as_ref())?;


### PR DESCRIPTION
This could also be extended to support other wasmtime-based profiling methods, for now just `perf` is supported.