### PR TITLE
release: Bump runtime to 0.4.0

### DIFF
--- a/dotnet/nuget/Extism.runtime.win.csproj
+++ b/dotnet/nuget/Extism.runtime.win.csproj
@@ -8,7 +8,7 @@
 
     <PropertyGroup>
         <PackageId>Extism.runtime.win-x64</PackageId>
-        <Version>0.5.0</Version>
+        <Version>0.6.0</Version>
         <Authors>Extism Contributors</Authors>
         <Description>Internal implementation package for Extism to work on Windows x64</Description>
         <Tags>extism, wasm, plugin</Tags>

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extism-runtime"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["The Extism Authors", "oss@extism.org"]
 license = "BSD-3-Clause"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ description = "Extism Host SDK for Rust"
 
 [dependencies]
 extism-manifest = { version = "0.3.0", path = "../manifest" }
-extism-runtime = { version = "0.3.0", path = "../runtime"}
+extism-runtime = { version = "0.4.0", path = "../runtime"}
 serde_json = "1"
 log = "0.4"
 anyhow = "1"


### PR DESCRIPTION
## Breaking Changes

* https://github.com/extism/extism/pull/315

HTTP calls will be disallowed by default now. If you want to enable HTTP you need to specify the hosts that the plug-in is allowed to communicate with. If you want to allow all hosts you can set it to `{allowed_hosts: ["*"]}` in the manifest. However, this isn't recommended unless you have some trust in the plug-in or are controlling the networking by some other means.

* https://github.com/extism/extism/pull/335

In this PR we are creating an implicit context so people don't need to know about it if they don't care. In some languages function signatures have changed to make context an optional argument when creating a plug-in.