### PR TITLE
fix(elixir): Fix nif package build and release as 0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,4 @@ members = [
   "runtime",
   "rust",
   "libextism",
-  "elixir/native/extism_nif"
 ]

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -4,7 +4,7 @@ defmodule Extism.MixProject do
   def project do
     [
       app: :extism,
-      version: "0.3.1",
+      version: "0.3.2",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -4,7 +4,7 @@ defmodule Extism.MixProject do
   def project do
     [
       app: :extism,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/elixir/native/extism_nif/Cargo.toml
+++ b/elixir/native/extism_nif/Cargo.toml
@@ -14,5 +14,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.28.0"
-extism = { version = "0.3.0", path = "../../../rust", package = "extism" }
+extism = "0.3.0"
 log = "0.4"

--- a/elixir/native/extism_nif/Cargo.toml
+++ b/elixir/native/extism_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extism_nif"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Benjamin Eckel <bhelx@simst.im>"]
 
@@ -8,6 +8,9 @@ authors = ["Benjamin Eckel <bhelx@simst.im>"]
 name = "extism_nif"
 path = "src/lib.rs"
 crate-type = ["cdylib"]
+
+# need this to be here and be empty
+[workspace]
 
 [dependencies]
 rustler = "0.28.0"


### PR DESCRIPTION
Published this fix as 0.3.2: https://github.com/extism/extism/issues/343

going to disconnect this rust project for the time being. If we want to publish a new elixir client with the new runtime then we must wait until the runtime hit's crates.io
