### PR TITLE
WASM/WASI threads support

### DIFF
--- a/dotnet/nuget/Extism.runtime.win.csproj
+++ b/dotnet/nuget/Extism.runtime.win.csproj
@@ -7,10 +7,11 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <PackageId>Extism.runtime.win-x64</PackageId>
-        <Version>0.6.0</Version>
+        <!-- TODO: Temporal package name. Real one: Extism.runtime.win-x64 -->
+        <PackageId>Extism.runtime.wasm-threads.win-x64</PackageId>
+        <Version>0.6.0-threads01</Version>
         <Authors>Extism Contributors</Authors>
-        <Description>Internal implementation package for Extism to work on Windows x64</Description>
+        <Description>Fork of the original Windows Extism 0.6.0 runtime with WASM threads feature enabled for Wasmtime, when EXTISM_WASM_THREADS env is passed.</Description>
         <Tags>extism, wasm, plugin</Tags>
         <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     </PropertyGroup>

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/extism/extism"
 description = "Extism runtime component"
 
 [dependencies]
-wasmtime = "8.0.0"
-wasmtime-wasi = "8.0.0"
-wasmtime-wasi-nn = {version = "8.0.0", optional=true}
+wasmtime = "9.0.2"
+wasmtime-wasi = "9.0.2"
+wasmtime-wasi-nn = {version = "9.0.2", optional=true}
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,6 +12,7 @@ description = "Extism runtime component"
 wasmtime = "9.0.2"
 wasmtime-wasi = "9.0.2"
 wasmtime-wasi-nn = {version = "9.0.2", optional=true}
+wasmtime-wasi-threads = "9.0.2"
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
@@ -26,6 +27,7 @@ extism-manifest = { version = "0.3.0", path = "../manifest" }
 pretty-hex = { version = "0.3" }
 uuid = { version = "1", features = ["v4"] }
 libc = "0.2"
+rand = "0.8.5"
 
 [features]
 default = ["http", "register-http", "register-filesystem"]

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -66,6 +66,7 @@ impl Plugin {
         // then we enable debug info
         let engine = Engine::new(
             Config::new()
+                .wasm_threads(std::env::var("EXTISM_WASM_THREADS").is_ok())
                 .epoch_interruption(true)
                 .debug_info(std::env::var("EXTISM_DEBUG").is_ok())
                 .profiler(profiling_strategy()),


### PR DESCRIPTION
### What it's all about

This is my in-progress work in adding WASI threads support that is required for running LLVM-based `.wasm` modules built with threading support. 

It also adds 2 env variables to enable threading features:
- `EXTISM_WASM_THREADS` for WASM threads
- `EXTISM_WASI_THREADS` for WASI threads

As a handy bonus, I've added `EXTISM_DEBUG` switch for enabling `.debug_info()`.

### Status

Currently, I have problems with implementing thread-safe wrappers over raw pointers used for input data (`Internal.input`) and plugin memory access (`Internal.memory`) propagation. It's required for [`spawn`](https://github.com/bytecodealliance/wasmtime/blob/main/crates/wasi-threads/src/lib.rs#L33) thread function coming from [`wasmtime-wasi-threads`](https://github.com/bytecodealliance/wasmtime/blob/main/crates/wasi-threads/README.md).

Also, there are some ownership conflicts with [`WasiThreadCtx`](https://github.com/bytecodealliance/wasmtime/blob/main/crates/wasi-threads/src/lib.rs#L18-L19), which wants to have ownership over `module` and `linker` for some reason, which is conflicting with local function ownership.

Once the issues above will be resolved, WASI threads should work as expected.

### .NET-specific

To not mess with the existing NuGet while testing I'm publishing working changes to the new NuGet `Extism.runtime.wasm-threads.win-x64` for local testing.

### My thoughts

Maybe only threads-specific stores should have an `Internal`-like structure with safe pointers to not break everything? 🤔 
Also, `Internal` is not quite a good name for such a structure, IMO. I propose something like `InstanceContext`. Then thread-specific struct will be `InstanceThreadContext`.

---

P.S. It's also worth bumping wasmtime dependencies versions, which I've already bumped in terms for the PR. Will revert if you have some sort of compatibility concerns.