### PR TITLE
chore: use a range for wasmtime dependency version

### DIFF
--- a/ocaml/manifest/extism_manifest.ml
+++ b/ocaml/manifest/extism_manifest.ml
@@ -1,3 +1,5 @@
+open Ppx_yojson_conv_lib.Yojson_conv
+
 type base64 = string
 
 let yojson_of_base64 x = `String (Base64.encode_exn x)

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/extism/extism"
 description = "Extism runtime component"
 
 [dependencies]
-wasmtime = "8.0.0"
-wasmtime-wasi = "8.0.0"
-wasmtime-wasi-nn = {version = "8.0.0", optional=true}
+wasmtime = ">= 8.0.0, < 11.0.0"
+wasmtime-wasi = ">= 8.0.0, < 11.0.0"
+wasmtime-wasi-nn = {version = ">= 8.0.0, < 11.0.0", optional=true}
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"


### PR DESCRIPTION
Currently wasmtime `8.0.0` - `10.0.0` are compatible with `extism-runtime`, in the interest of remaining compatible with as many applications as possible, this PR updates the wasmtime version requirement from a single version to a range of acceptable versions.
