### PR TITLE
fix: avoid timeout errors outside of `extism_plugin_call`

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/extism/extism"
 description = "Extism runtime component"
 
 [dependencies]
-wasmtime = ">= 8.0.0, < 12.0.0"
-wasmtime-wasi = ">= 8.0.0, < 12.0.0"
-wasmtime-wasi-nn = {version = ">= 8.0.0, < 12.0.0", optional=true}
+wasmtime = ">= 10.0.0, < 12.0.0"
+wasmtime-wasi = ">= 10.0.0, < 12.0.0"
+wasmtime-wasi-nn = {version = ">= 10.0.0, < 12.0.0", optional=true}
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -336,7 +336,6 @@ impl Plugin {
             }
             self.instantiations = 0;
             self.instance_pre = self.linker.instantiate_pre(&main)?;
-            self.instance = None;
 
             let store = &mut self.store as *mut _;
             let linker = &mut self.linker as *mut _;
@@ -345,6 +344,7 @@ impl Plugin {
             internal.linker = linker;
         }
 
+        self.instance = None;
         self.instantiations += 1;
         Ok(())
     }

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -12,7 +12,8 @@ pub struct Plugin {
     pub store: Store<Internal>,
 
     /// Instance provides the ability to call functions in a module
-    pub instance: Instance,
+    pub instance: Option<Instance>,
+    pub instance_pre: InstancePre<Internal>,
 
     /// Keep track of the number of times we're instantiated, this exists
     /// to avoid issues with memory piling up since `Instance`s are only
@@ -222,12 +223,13 @@ impl Plugin {
             }
         }
 
-        let instance = linker.instantiate(&mut store, main)?;
+        let instance_pre = linker.instantiate_pre(&main)?;
         let timer_id = uuid::Uuid::new_v4();
         let mut plugin = Plugin {
             modules,
             linker,
-            instance,
+            instance: None,
+            instance_pre,
             store,
             instantiations: 1,
             runtime: None,
@@ -240,24 +242,27 @@ impl Plugin {
 
         plugin.internal_mut().store = &mut plugin.store;
         plugin.internal_mut().linker = &mut plugin.linker;
-
-        // Then detect runtime before returning the new plugin
-        plugin.detect_runtime();
         Ok(plugin)
     }
 
     /// Get a function by name
     pub fn get_func(&mut self, function: impl AsRef<str>) -> Option<Func> {
-        self.instance.get_func(&mut self.store, function.as_ref())
+        if let None = &self.instance {
+            if let Ok(x) = self.instance_pre.instantiate(&mut self.store) {
+                self.instance = Some(x);
+                self.detect_runtime();
+            }
+        }
+
+        if let Some(instance) = &mut self.instance {
+            instance.get_func(&mut self.store, function.as_ref())
+        } else {
+            None
+        }
     }
 
     /// Store input in memory and initialize `Internal` pointer
-    pub(crate) fn set_input(
-        &mut self,
-        input: *const u8,
-        mut len: usize,
-        tx: std::sync::mpsc::SyncSender<TimerAction>,
-    ) -> Result<(), Error> {
+    pub(crate) fn set_input(&mut self, input: *const u8, mut len: usize) -> Result<(), Error> {
         if input.is_null() {
             len = 0;
         }
@@ -273,7 +278,6 @@ impl Plugin {
         let bytes = unsafe { std::slice::from_raw_parts(input, len) };
         trace!("Input size: {}", bytes.len());
 
-        self.start_timer(&tx)?;
         if let Some(f) = self.linker.get(&mut self.store, "env", "extism_reset") {
             f.into_func().unwrap().call(&mut self.store, &[], &mut [])?;
         }
@@ -331,11 +335,16 @@ impl Plugin {
                 }
             }
             self.instantiations = 0;
+            self.instance_pre = self.linker.instantiate_pre(&main)?;
+            self.instance = None;
+
+            let store = &mut self.store as *mut _;
+            let linker = &mut self.linker as *mut _;
+            let internal = self.internal_mut();
+            internal.store = store;
+            internal.linker = linker;
         }
 
-        let instance = self.linker.instantiate(&mut self.store, main)?;
-        self.instance = instance;
-        self.detect_runtime();
         self.instantiations += 1;
         Ok(())
     }

--- a/runtime/src/plugin_ref.rs
+++ b/runtime/src/plugin_ref.rs
@@ -42,15 +42,6 @@ impl<'a> PluginRef<'a> {
         };
 
         let plugin = unsafe { &mut *plugin };
-        // Start timer
-        // if let Err(e) = plugin.start_timer(&epoch_timer_tx) {
-        //     let id = plugin.timer_id;
-        //     ctx.error(
-        //         format!("Unable to start timeout manager for {id}: {e:?}"),
-        //         (),
-        //     );
-        //     return None;
-        // }
 
         if clear_error {
             trace!("Clearing context error");

--- a/runtime/src/plugin_ref.rs
+++ b/runtime/src/plugin_ref.rs
@@ -41,26 +41,22 @@ impl<'a> PluginRef<'a> {
             return ctx.error(format!("Plugin does not exist: {plugin_id}"), None);
         };
 
-        {
-            let plugin = unsafe { &mut *plugin };
-            // Start timer
-            if let Err(e) = plugin.start_timer(&epoch_timer_tx) {
-                let id = plugin.timer_id;
-                plugin.error(
-                    format!("Unable to start timeout manager for {id}: {e:?}"),
-                    (),
-                );
-                return None;
-            }
-        }
+        let plugin = unsafe { &mut *plugin };
+        // Start timer
+        // if let Err(e) = plugin.start_timer(&epoch_timer_tx) {
+        //     let id = plugin.timer_id;
+        //     ctx.error(
+        //         format!("Unable to start timeout manager for {id}: {e:?}"),
+        //         (),
+        //     );
+        //     return None;
+        // }
 
         if clear_error {
             trace!("Clearing context error");
             ctx.error = None;
             trace!("Clearing plugin error: {plugin_id}");
-            unsafe {
-                (*plugin).clear_error();
-            }
+            plugin.clear_error();
         }
 
         Some(PluginRef {

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -504,11 +504,6 @@ pub unsafe extern "C" fn extism_plugin_call(
     let tx = plugin_ref.epoch_timer_tx.clone();
     let plugin = plugin_ref.as_mut();
 
-    // Start timer, this will be stopped when PluginRef goes out of scope
-    if let Err(e) = plugin.start_timer(&tx) {
-        return plugin.error(e, -1);
-    }
-
     // Find function
     let name = std::ffi::CStr::from_ptr(func_name);
     let name = match name.to_str() {
@@ -531,6 +526,10 @@ pub unsafe extern "C" fn extism_plugin_call(
         );
     }
 
+    if let Err(e) = plugin.set_input(data, data_len as usize) {
+        return plugin.error(e, -1);
+    }
+
     // Initialize runtime
     if !is_start {
         if let Err(e) = plugin.initialize_runtime() {
@@ -538,12 +537,13 @@ pub unsafe extern "C" fn extism_plugin_call(
         }
     }
 
-    if let Err(e) = plugin.set_input(data, data_len as usize) {
-        return plugin.error(e, -1);
-    }
-
     if plugin.has_error() {
         return -1;
+    }
+
+    // Start timer, this will be stopped when PluginRef goes out of scope
+    if let Err(e) = plugin.start_timer(&tx) {
+        return plugin.error(e, -1);
     }
 
     debug!("Calling function: {name} in plugin {plugin_id}");

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -504,6 +504,11 @@ pub unsafe extern "C" fn extism_plugin_call(
     let tx = plugin_ref.epoch_timer_tx.clone();
     let plugin = plugin_ref.as_mut();
 
+    // Start timer, this will be stopped when PluginRef goes out of scope
+    if let Err(e) = plugin.start_timer(&tx) {
+        return plugin.error(e, -1);
+    }
+
     // Find function
     let name = std::ffi::CStr::from_ptr(func_name);
     let name = match name.to_str() {
@@ -533,7 +538,7 @@ pub unsafe extern "C" fn extism_plugin_call(
         }
     }
 
-    if let Err(e) = plugin.set_input(data, data_len as usize, tx) {
+    if let Err(e) = plugin.set_input(data, data_len as usize) {
         return plugin.error(e, -1);
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -283,4 +283,24 @@ mod tests {
         println!("Cancelled plugin ran for {:?}", time);
         // std::io::stdout().write_all(output).unwrap();
     }
+
+    #[test]
+    fn test_multiple_instantiations() {
+        let f = Function::new(
+            "hello_world",
+            [ValType::I64],
+            [ValType::I64],
+            None,
+            hello_world,
+        );
+
+        let context = Context::new();
+        let mut plugin = Plugin::new(&context, WASM, [f], true).unwrap();
+
+        // This is 10,001 because the wasmtime store limit is 10,000 - we want to test
+        // that our reinstantiation process is working and that limit is never hit.
+        for _ in 0..10001 {
+            let _output = plugin.call("count_vowels", "abc123").unwrap();
+        }
+    }
 }


### PR DESCRIPTION
- Delays instantiation to right before a call by using `instantiate_pre` instead. This fixes an issue with the assemblyscript PDK.
- Makes timeouts only apply to calls
- Also bumps the wasmtime lower-bounds to 10.0, because the return type of the epoch callback has changed