### PR TITLE
fix: remove call to bash from build.rs

### DIFF
--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -2,6 +2,6 @@
 
 cargo build --release --target wasm32-unknown-unknown --package extism-runtime-kernel --bin extism-runtime
 cp target/wasm32-unknown-unknown/release/extism-runtime.wasm .
-wasm-strip extism-runtime.wasm || :
+wasm-strip extism-runtime.wasm
 mv extism-runtime.wasm ../runtime/src/extism-runtime.wasm
 

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -1,15 +1,5 @@
 fn main() {
     println!("cargo:rerun-if-changed=src/extism-runtime.wasm");
-    let dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
-
-    // Attempt to build the kernel, this is only done as a convenience when developing the
-    // kernel an should not be relied on. When changes are made to the kernel run
-    // `sh build.sh` in the `kernel/` directory to ensure it run successfully.
-    let _ = std::process::Command::new("bash")
-        .args(&["build.sh"])
-        .current_dir(dir.join("../kernel"))
-        .status()
-        .unwrap();
 
     let fn_macro = "
 #define EXTISM_FUNCTION(N) extern void N(ExtismCurrentPlugin*, const ExtismVal*, ExtismSize, ExtismVal*, ExtismSize, void*)


### PR DESCRIPTION
I think this will fix the issue with CI hanging - this fixes the issue when building Elixir, which seems to be the same as the CI issue