### PR TITLE
feat: Add `EXTISM_ENABLE_WASI_OUTPUT` to inherit stdout/stderr

### DIFF
--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -132,6 +132,18 @@ impl CurrentPlugin {
                 }
             }
 
+            if std::env::var("EXTISM_STDOUT").is_ok() {
+                ctx = ctx.inherit_stdout();
+            }
+
+            if std::env::var("EXTISM_STDERR").is_ok() {
+                ctx = ctx.inherit_stderr();
+            }
+
+            if std::env::var("EXTISM_STDIN").is_ok() {
+                ctx = ctx.inherit_stdin();
+            }
+
             #[cfg(feature = "nn")]
             let nn = wasmtime_wasi_nn::WasiNnCtx::new()?;
 

--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -132,16 +132,9 @@ impl CurrentPlugin {
                 }
             }
 
-            if std::env::var("EXTISM_STDOUT").is_ok() {
-                ctx = ctx.inherit_stdout();
-            }
-
-            if std::env::var("EXTISM_STDERR").is_ok() {
-                ctx = ctx.inherit_stderr();
-            }
-
-            if std::env::var("EXTISM_STDIN").is_ok() {
-                ctx = ctx.inherit_stdin();
+            // Enable WASI output, typically used for debugging purposes
+            if std::env::var("EXTISM_ENABLE_WASI_OUTPUT").is_ok() {
+                ctx = ctx.inherit_stdout().inherit_stderr();
             }
 
             #[cfg(feature = "nn")]


### PR DESCRIPTION
@mhmd-azeez pointed out that exposing an option like this can be very useful for debugging if the program is expecting to run in a full WASI environment.