### PR TITLE
fix: toml manifests load the extism runtime

### DIFF
--- a/runtime/src/manifest.rs
+++ b/runtime/src/manifest.rs
@@ -171,7 +171,8 @@ pub(crate) fn load(
     if !has_magic && !is_wast {
         if let Ok(s) = std::str::from_utf8(data) {
             if let Ok(t) = toml::from_str::<extism_manifest::Manifest>(s) {
-                let m = modules(&t, engine)?;
+                let mut m = modules(&t, engine)?;
+                m.insert("env".to_string(), extism_module);
                 return Ok((t, m));
             }
         }

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -177,7 +177,7 @@ impl Plugin {
         imports: impl IntoIterator<Item = Function>,
         with_wasi: bool,
     ) -> Result<Plugin, Error> {
-        // Create a new engine, if the `EXITSM_DEBUG` environment variable is set
+        // Create a new engine, if the `EXTISM_DEBUG` environment variable is set
         // then we enable debug info
         let engine = Engine::new(
             Config::new()

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -243,3 +243,24 @@ fn test_globals() {
         assert_eq!(count.get("count").unwrap().as_i64().unwrap(), i);
     }
 }
+
+#[test]
+fn test_toml_manifest() {
+    let f = Function::new(
+        "hello_world",
+        [ValType::I64],
+        [ValType::I64],
+        None,
+        hello_world,
+    );
+
+    let manifest = Manifest::new([extism_manifest::Wasm::data(WASM)])
+        .with_timeout(std::time::Duration::from_secs(1));
+
+    let manifest_toml = toml::to_string_pretty(&manifest).unwrap();
+    let mut plugin = Plugin::new(manifest_toml.as_bytes(), [f], true).unwrap();
+
+    let output = plugin.call("count_vowels", "abc123").unwrap();
+    let count: serde_json::Value = serde_json::from_slice(output).unwrap();
+    assert_eq!(count.get("count").unwrap().as_i64().unwrap(), 1);
+}


### PR DESCRIPTION
Just getting my feet wet with the codebase a little bit! I noticed that TOML manifests weren't loading the extism runtime by default while doing a walkthrough. This commit ensures the runtime is loaded and adds a test.

Also, fix a tiny typo in a comment.