### PR TITLE
feat(ocaml): add missing flags to `extism-call` executable

### DIFF
--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -1,6 +1,8 @@
 VERSION?=0.4.0
 TAG?=0.5.0
 
+PREFIX?=$$HOME/.local
+
 build:
 	dune build
 
@@ -14,3 +16,6 @@ prepare:
 
 publish:
 	opam publish -v $(VERSION) https://github.com/extism/extism/archive/refs/tags/v$(TAG).tar.gz ..
+
+install-cli: build
+	install ../_build/default/ocaml/bin/main.exe "$(PREFIX)/bin/extism-run"

--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -18,4 +18,4 @@ publish:
 	opam publish -v $(VERSION) https://github.com/extism/extism/archive/refs/tags/v$(TAG).tar.gz ..
 
 install-cli: build
-	install ../_build/default/ocaml/bin/main.exe "$(PREFIX)/bin/extism-run"
+	install ../_build/default/ocaml/bin/main.exe "$(PREFIX)/bin/extism-call"

--- a/ocaml/bin/dune
+++ b/ocaml/bin/dune
@@ -1,5 +1,5 @@
 (executable
  (name main)
  (package extism)
- (public_name extism-run)
+ (public_name extism-call)
  (libraries extism cmdliner))

--- a/ocaml/bin/main.ml
+++ b/ocaml/bin/main.ml
@@ -58,11 +58,11 @@ let main file func_name input loop timeout_ms allowed_paths allowed_hosts config
 
 let file =
   let doc = "The Wasm module or Extism manifest path." in
-  Arg.(value & pos 0 file "" & info [] ~docv:"FILE" ~doc)
+  Arg.(required & pos 0 (some file) None & info [] ~docv:"FILE" ~doc)
 
 let func_name =
   let doc = "The function to run." in
-  Arg.(value & pos 1 string "_start" & info [] ~docv:"NAME" ~doc)
+  Arg.(required & pos 1 (some string) None & info [] ~docv:"NAME" ~doc)
 
 let input =
   let doc = "Input data." in

--- a/ocaml/bin/main.ml
+++ b/ocaml/bin/main.ml
@@ -84,7 +84,7 @@ let allowed_paths =
   let doc = "Allowed paths." in
   Arg.(
     value & opt_all string []
-    & info [ "allow-path" ] ~docv:"PATH[:PLUGIN_PATH]" ~doc)
+    & info [ "allow-path" ] ~docv:"LOCAL_PATH[:PLUGIN_PATH]" ~doc)
 
 let allowed_hosts =
   let doc = "Allowed hosts for HTTP requests." in

--- a/ocaml/bin/main.ml
+++ b/ocaml/bin/main.ml
@@ -49,11 +49,16 @@ let main file func_name input loop timeout_ms allowed_paths allowed_hosts config
   let plugin =
     match Plugin.of_manifest manifest ~wasi with
     | Ok x -> x
-    | Error e -> Error.throw e
+    | Error (`Msg e) ->
+        Printf.eprintf "ERROR Unable to load plugin: %s" e;
+        exit 1
   in
   for _ = 0 to loop do
-    let res = Plugin.call plugin ~name:func_name input |> Result.get_ok in
-    print_endline res
+    match Plugin.call plugin ~name:func_name input with
+    | Ok res -> print_endline res
+    | Error (`Msg e) ->
+        Printf.eprintf "ERROR Unable to call function: %s" e;
+        exit 2
   done
 
 let file =

--- a/ocaml/bin/main.ml
+++ b/ocaml/bin/main.ml
@@ -3,13 +3,37 @@ open Cmdliner
 
 let read_stdin () = In_channel.input_all stdin
 
-let main file func_name input =
+let split_allowed_paths =
+  List.filter_map (fun path ->
+      let s = String.split_on_char ':' path in
+      match s with
+      | [] -> None
+      | [ p ] -> Some (p, p)
+      | p :: tl -> Some (p, String.concat ":" tl))
+
+let main file func_name input loop timeout_ms allowed_paths allowed_hosts
+    manifest =
   let input = if String.equal input "-" then read_stdin () else input in
   let file = In_channel.with_open_bin file In_channel.input_all in
-  let plugin = Plugin.create file ~wasi:true |> Result.get_ok in
-  print_endline (Plugin.id plugin |> Uuidm.to_string);
-  let res = Plugin.call plugin ~name:func_name input |> Result.get_ok in
-  print_endline res
+  let allowed_paths = split_allowed_paths allowed_paths in
+  let manifest =
+    if manifest then
+      let m = Manifest.of_file file in
+      {
+        m with
+        timeout_ms = Some timeout_ms;
+        allowed_hosts = Some allowed_hosts;
+        allowed_paths = Some allowed_paths;
+      }
+    else
+      Manifest.create ~timeout_ms ~allowed_hosts ~allowed_paths
+        [ Manifest.(Wasm.File { path = file; hash = None; name = None }) ]
+  in
+  let plugin = Plugin.of_manifest manifest ~wasi:true |> Result.get_ok in
+  for _ = 0 to loop do
+    let res = Plugin.call plugin ~name:func_name input |> Result.get_ok in
+    print_endline res
+  done
 
 let file =
   let doc = "The WASM module or Extism manifest path." in
@@ -23,6 +47,30 @@ let input =
   let doc = "Input data." in
   Arg.(value & opt string "" & info [ "input"; "i" ] ~docv:"INPUT" ~doc)
 
-let main_t = Term.(const main $ file $ func_name $ input)
+let loop =
+  let doc = "Number of times to call the plugin." in
+  Arg.(value & opt int 1 & info [ "loop" ] ~docv:"TIMES" ~doc)
+
+let timeout =
+  let doc = "Plugin timeout in milliseconds." in
+  Arg.(value & opt int 30000 & info [ "timeout"; "t" ] ~docv:"MILLIS" ~doc)
+
+let allowed_paths =
+  let doc = "Allowed paths." in
+  Arg.(value & opt_all string [] & info [ "allow-path" ] ~docv:"PATH" ~doc)
+
+let allowed_hosts =
+  let doc = "Allowed hosts for HTTP requests." in
+  Arg.(value & opt_all string [] & info [ "allow-host" ] ~docv:"HOST" ~doc)
+
+let manifest =
+  let doc = "Use Manifest instead of raw Wasm on disk." in
+  Arg.(value & flag & info [ "manifest" ] ~doc)
+
+let main_t =
+  Term.(
+    const main $ file $ func_name $ input $ loop $ timeout $ allowed_paths
+    $ allowed_hosts $ manifest)
+
 let cmd = Cmd.v (Cmd.info "extism-run") main_t
 let () = exit (Cmd.eval cmd)


### PR DESCRIPTION
`extism-call` is a test program using the OCaml SDK, this PR adds the missing flags to make it a little more useful for general testing/