### PR TITLE
feat(build): Add "latest" snapshot builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ on:
   release:
     types: [created]
   workflow_dispatch:
+  push:
+    branches: [ main ]
 
 name: Release
 
@@ -36,6 +38,12 @@ jobs:
           profile: minimal
           override: true
           target: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "linux-${{matrix.target}}"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: "true"
 
       - name: Build Target (${{ matrix.target }})
         uses: actions-rs/cargo@v1
@@ -81,6 +89,7 @@ jobs:
           files: |
             *.tar.gz
             *.txt
+        if: startsWith(github.ref, 'refs/tags/')
 
   release-macos:
     name: macos
@@ -100,6 +109,12 @@ jobs:
           profile: minimal
           override: true
           target: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "macos-${{matrix.target}}"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: "true"
 
       - name: Build Target (${{ matrix.target }})
         uses: actions-rs/cargo@v1
@@ -145,6 +160,7 @@ jobs:
           files: |
             *.tar.gz
             *.txt
+        if: startsWith(github.ref, 'refs/tags/')
 
   release-windows:
     name: windows
@@ -168,6 +184,12 @@ jobs:
           profile: minimal
           override: true
           target: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "macos-${{matrix.target}}"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: "true"
 
       - name: Build Target (${{ matrix.target }})
         uses: actions-rs/cargo@v1
@@ -214,3 +236,25 @@ jobs:
           files: |
             *.tar.gz
             *.txt
+        if: startsWith(github.ref, 'refs/tags/')
+
+  release-latest:
+    name: create latest release
+    runs-on: ubuntu-latest
+    needs: [release-linux, release-macos, release-windows]
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT_DIR }}
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            *.tar.gz
+            *.txt
+        if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Add a "latest" snapshot that other libraries can use to test against the latest version of Extism.

Add caching for builds triggered by pushes to `main`.