### PR TITLE
cleanup(runtime): remove restrictions around `memory.max_pages` option, fix crash

### DIFF
--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -237,6 +237,12 @@ impl Manifest {
         self
     }
 
+    /// Set MemoryOptions::memory_max
+    pub fn with_memory_max(mut self, max: u32) -> Self {
+        self.memory.max_pages = Some(max);
+        return self;
+    }
+
     /// Add a hostname to `allowed_hosts`
     pub fn with_allowed_host(mut self, host: impl Into<String>) -> Self {
         match &mut self.allowed_hosts {

--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -37,8 +37,8 @@ impl wasmtime::ResourceLimiter for MemoryLimiter {
         maximum: Option<usize>,
     ) -> Result<bool> {
         if let Some(max) = maximum {
-            if desired > max {
-                return Ok(false);
+            if desired >= max {
+                return Err(Error::msg("oom"));
             }
         }
 

--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -44,7 +44,7 @@ impl wasmtime::ResourceLimiter for MemoryLimiter {
 
         let d = desired - current;
         if d > self.bytes_left {
-            return Ok(false);
+            return Err(Error::msg("oom"));
         }
 
         self.bytes_left -= d;

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -608,8 +608,9 @@ impl Plugin {
                     return Ok(0);
                 }
                 Err(e) => {
-                    if e.root_cause().to_string() == "timeout" {
-                        return Err((Error::msg("timeout"), -1));
+                    let cause = e.root_cause().to_string();
+                    if cause == "timeout" || cause == "oom" {
+                        return Err((Error::msg(cause), -1));
                     }
 
                     error!("Call: {e:?}");

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -669,6 +669,7 @@ impl Plugin {
         x: E,
     ) -> E {
         if instance_lock.is_none() {
+            error!("No instance, unable to set error: {:?}", e);
             return x;
         }
         let s = format!("{e:?}");

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -310,15 +310,22 @@ fn test_fuzz_reflect_plugin() {
 fn test_memory_max() {
     // Should fail with memory.max set
     let manifest =
-        Manifest::new([extism_manifest::Wasm::data(WASM_NO_FUNCTIONS)]).with_memory_max(17);
+        Manifest::new([extism_manifest::Wasm::data(WASM_NO_FUNCTIONS)]).with_memory_max(16);
     let mut plugin = Plugin::new_with_manifest(&manifest, [], true).unwrap();
-    let output: Result<String, Error> = plugin.call("count_vowels", "aaaaaaaaaa".repeat(65536 * 2));
+    let output: Result<String, Error> = plugin.call("count_vowels", "a".repeat(65536 * 2));
     assert!(output.is_err());
     assert!(output.unwrap_err().root_cause().to_string() == "oom");
+
+    // Should pass with memory.max set to a large enough number
+    let manifest =
+        Manifest::new([extism_manifest::Wasm::data(WASM_NO_FUNCTIONS)]).with_memory_max(17);
+    let mut plugin = Plugin::new_with_manifest(&manifest, [], true).unwrap();
+    let output: Result<String, Error> = plugin.call("count_vowels", "a".repeat(65536 * 2));
+    assert!(output.is_ok());
 
     // Should pass without it
     let manifest = Manifest::new([extism_manifest::Wasm::data(WASM_NO_FUNCTIONS)]);
     let mut plugin = Plugin::new_with_manifest(&manifest, [], true).unwrap();
-    let output: Result<String, Error> = plugin.call("count_vowels", "aaaaaaaaaa".repeat(65536 * 2));
+    let output: Result<String, Error> = plugin.call("count_vowels", "a".repeat(65536 * 2));
     assert!(output.is_ok());
 }

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -210,10 +210,11 @@ fn test_timeout() {
     let mut plugin = Plugin::new_with_manifest(&manifest, [f], true).unwrap();
 
     let start = std::time::Instant::now();
-    let _output: Result<&[u8], Error> = plugin.call("infinite_loop", "abc123");
+    let output: Result<&[u8], Error> = plugin.call("infinite_loop", "abc123");
     let end = std::time::Instant::now();
     let time = end - start;
     println!("Timed out plugin ran for {:?}", time);
+    assert!(output.unwrap_err().root_cause().to_string() == "timeout");
     // std::io::stdout().write_all(output).unwrap();
 }
 
@@ -313,6 +314,7 @@ fn test_memory_max() {
     let mut plugin = Plugin::new_with_manifest(&manifest, [], true).unwrap();
     let output: Result<String, Error> = plugin.call("count_vowels", "aaaaaaaaaa".repeat(65536 * 2));
     assert!(output.is_err());
+    assert!(output.unwrap_err().root_cause().to_string() == "oom");
 
     // Should pass without it
     let manifest = Manifest::new([extism_manifest::Wasm::data(WASM_NO_FUNCTIONS)]);

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use std::time::Instant;
 
 const WASM: &[u8] = include_bytes!("../../wasm/code-functions.wasm");
+const WASM_NO_FUNCTIONS: &[u8] = include_bytes!("../../wasm/code.wasm");
 const WASM_LOOP: &[u8] = include_bytes!("../../wasm/loop.wasm");
 const WASM_GLOBALS: &[u8] = include_bytes!("../../wasm/globals.wasm");
 const WASM_REFLECT: &[u8] = include_bytes!("../../wasm/reflect.wasm");
@@ -272,19 +273,11 @@ fn test_globals() {
 
 #[test]
 fn test_toml_manifest() {
-    let f = Function::new(
-        "hello_world",
-        [ValType::I64],
-        [ValType::I64],
-        None,
-        hello_world,
-    );
-
-    let manifest = Manifest::new([extism_manifest::Wasm::data(WASM)])
+    let manifest = Manifest::new([extism_manifest::Wasm::data(WASM_NO_FUNCTIONS)])
         .with_timeout(std::time::Duration::from_secs(1));
 
     let manifest_toml = toml::to_string_pretty(&manifest).unwrap();
-    let mut plugin = Plugin::new(manifest_toml.as_bytes(), [f], true).unwrap();
+    let mut plugin = Plugin::new(manifest_toml.as_bytes(), [], true).unwrap();
 
     let output = plugin.call("count_vowels", "abc123").unwrap();
     let count: serde_json::Value = serde_json::from_slice(output).unwrap();
@@ -310,4 +303,20 @@ fn test_fuzz_reflect_plugin() {
         let output = std::str::from_utf8(output.unwrap()).unwrap();
         assert_eq!(output, input);
     }
+}
+
+#[test]
+fn test_memory_max() {
+    // Should fail with memory.max set
+    let manifest =
+        Manifest::new([extism_manifest::Wasm::data(WASM_NO_FUNCTIONS)]).with_memory_max(17);
+    let mut plugin = Plugin::new_with_manifest(&manifest, [], true).unwrap();
+    let output: Result<String, Error> = plugin.call("count_vowels", "aaaaaaaaaa".repeat(65536 * 2));
+    assert!(output.is_err());
+
+    // Should pass without it
+    let manifest = Manifest::new([extism_manifest::Wasm::data(WASM_NO_FUNCTIONS)]);
+    let mut plugin = Plugin::new_with_manifest(&manifest, [], true).unwrap();
+    let output: Result<String, Error> = plugin.call("count_vowels", "aaaaaaaaaa".repeat(65536 * 2));
+    assert!(output.is_ok());
 }


### PR DESCRIPTION
- Removes restrictions around when `memory.max_pages` setting can be used. Before we used `wasmtime::MemoryLimiter` it was hard to determine how much was being allocated at runtime, so we used to calculate the totals statically, which required every module to have a maximum memory set at compile time. This PR allows `memory.max` to be used on any module!
- Fixes a crash when the `memory.max_pages` field is set
- Adds a test that checks for failure when allocating more than configured