### PR TITLE
chore: bump wasmtime lower bound to 13.0.0, remove wasi-nn support

### DIFF
--- a/libextism/Cargo.toml
+++ b/libextism/Cargo.toml
@@ -18,7 +18,6 @@ extism = {path = "../runtime"}
 
 [features]
 default = ["http", "register-http", "register-filesystem"]
-nn = ["extism/nn"]
 register-http = ["extism/register-http"] # enables wasm to be downloaded using http
 register-filesystem = ["extism/register-filesystem"] # enables wasm to be loaded from disk
 http = ["extism/http"] # enables extism_http_request

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/extism/extism"
 description = "Extism runtime and Rust SDK"
 
 [dependencies]
-wasmtime = ">= 10.0.0, < 14.0.0"
-wasmtime-wasi = ">= 10.0.0, < 14.0.0"
+wasmtime = ">= 13.0.0, < 14.0.0"
+wasmtime-wasi = ">= 13.0.0, < 14.0.0"
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,7 +11,6 @@ description = "Extism runtime and Rust SDK"
 [dependencies]
 wasmtime = ">= 10.0.0, < 14.0.0"
 wasmtime-wasi = ">= 10.0.0, < 14.0.0"
-wasmtime-wasi-nn = {version = ">= 10.0.0, < 14.0.0", optional=true}
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
@@ -29,7 +28,6 @@ libc = "0.2"
 
 [features]
 default = ["http", "register-http", "register-filesystem"]
-nn = ["wasmtime-wasi-nn"]
 register-http = ["ureq"] # enables wasm to be downloaded using http
 register-filesystem = [] # enables wasm to be loaded from disk
 http = ["ureq"]          # enables extism_http_request

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/extism/extism"
 description = "Extism runtime and Rust SDK"
 
 [dependencies]
-wasmtime = ">= 10.0.0, < 13.0.0"
-wasmtime-wasi = ">= 10.0.0, < 13.0.0"
-wasmtime-wasi-nn = {version = ">= 10.0.0, < 13.0.0", optional=true}
+wasmtime = ">= 10.0.0, < 14.0.0"
+wasmtime-wasi = ">= 10.0.0, < 14.0.0"
+wasmtime-wasi-nn = {version = ">= 10.0.0, < 14.0.0", optional=true}
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -202,29 +202,22 @@ impl CurrentPlugin {
             let auth = wasmtime_wasi::ambient_authority();
             let mut ctx = wasmtime_wasi::WasiCtxBuilder::new();
             for (k, v) in manifest.config.iter() {
-                ctx = ctx.env(k, v)?;
+                ctx.env(k, v)?;
             }
 
             if let Some(a) = &manifest.allowed_paths {
                 for (k, v) in a.iter() {
                     let d = wasmtime_wasi::Dir::open_ambient_dir(k, auth)?;
-                    ctx = ctx.preopened_dir(d, v)?;
+                    ctx.preopened_dir(d, v)?;
                 }
             }
 
             // Enable WASI output, typically used for debugging purposes
             if std::env::var("EXTISM_ENABLE_WASI_OUTPUT").is_ok() {
-                ctx = ctx.inherit_stdout().inherit_stderr();
+                ctx.inherit_stdout().inherit_stderr();
             }
 
-            #[cfg(feature = "nn")]
-            let nn = wasmtime_wasi_nn::WasiNnCtx::new()?;
-
-            Some(Wasi {
-                ctx: ctx.build(),
-                #[cfg(feature = "nn")]
-                nn,
-            })
+            Some(Wasi { ctx: ctx.build() })
         } else {
             None
         };

--- a/runtime/src/internal.rs
+++ b/runtime/src/internal.rs
@@ -4,10 +4,6 @@ use crate::*;
 pub struct Wasi {
     /// wasi
     pub ctx: wasmtime_wasi::WasiCtx,
-
-    /// wasi-nn
-    #[cfg(feature = "nn")]
-    pub nn: wasmtime_wasi_nn::WasiNnCtx,
 }
 
 /// InternalExt provides a unified way of acessing `memory`, `store` and `internal` values

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -230,12 +230,8 @@ impl Plugin {
             wasmtime_wasi::add_to_linker(&mut linker, |x: &mut CurrentPlugin| {
                 &mut x.wasi.as_mut().unwrap().ctx
             })?;
-
-            #[cfg(feature = "nn")]
-            wasmtime_wasi_nn::add_to_linker(&mut linker, |x: &mut CurrentPlugin| {
-                &mut x.wasi.as_mut().unwrap().nn
-            })?;
         }
+
         // Get the `main` module, or the last one if `main` doesn't exist
         let (main_name, main) = modules.get("main").map(|x| ("main", x)).unwrap_or_else(|| {
             let entry = modules.iter().last().unwrap();


### PR DESCRIPTION
- Updates to wasmtime 13.0.0 as the lowest supported version
- Removes `wasmtime-wasi-nn` support because it now takes parameters to specify particular backends and registries during initialization. Since I don't think anyone is using the `nn` feature I chose to remove it for now, but we could also expand the manifest to add these options.