### PR TITLE
chore: fix elixir release action

### DIFF
--- a/.github/workflows/release-elixir.yaml
+++ b/.github/workflows/release-elixir.yaml
@@ -10,13 +10,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install extism shared library
-        shell: bash
-        run: |
-          mkdir -p /home/runner/.local/bin/  
-          export PATH="/home/runner/.local/bin/:$PATH"
-          curl https://raw.githubusercontent.com/extism/cli/main/install.sh | sh
-          extism --sudo --prefix /usr/local install
       - name: Setup Elixir Host SDK
         uses: erlef/setup-beam@v1
         with:


### PR DESCRIPTION
This is 404ing for some reason. But Elixir doesn't need the shared library so i'm removing it.

https://github.com/extism/extism/actions/runs/6425026823/job/17446865267