### PR TITLE
feat(build): GHA release-python now releases extism_sys packages

### DIFF
--- a/.github/workflows/release-python.yaml
+++ b/.github/workflows/release-python.yaml
@@ -1,7 +1,8 @@
-on:
-  workflow_dispatch:
-
 name: Release Python SDK
+
+on:
+  release:
+    types: [published, edited]
 
 jobs:
   release-sdks:
@@ -11,26 +12,31 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Python env
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-          check-latest: true
-      - name: Run image
-        uses: abatilo/actions-poetry@v2
+      - name: Install poetry
+        run: pipx install poetry
 
-      - name: Build Python Host SDK
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'poetry'
+
+      - name: install twine
         run: |
-          cd python
-          cp ../LICENSE .
-          make clean
-          poetry install --no-dev
-          poetry build
+          pip install twine
 
-      - name: Release Python Host SDK
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: ${{ secrets.PYPI_API_USER }}
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          packages_dir: python/dist/
+      - name: download release
+        run: |
+          tag='${{ github.ref }}'
+          tag="${tag/refs\/tags\//}"
+          mkdir dist
+          cd dist
+          gh release download "$tag" -p 'extism_sys-*'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: upload release
+        run: |
+          twine upload dist/*
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_API_USER }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This changes the workflow slightly: whenever we publish a draft release, download our `*.whl` assets from that release and publish them to PyPI.