### PR TITLE
ci: try zig test with more work for plugin pass

### DIFF
--- a/zig/test.zig
+++ b/zig/test.zig
@@ -46,9 +46,13 @@ test "Single threaded tests" {
     std.debug.print("--------------\n", .{});
     var i: usize = 0;
     var wasm_elapsed: u64 = 0;
+    var wasm_count: u32 = 0;
     while (i < 100) : (i += 1) {
         var call_start = try std.time.Timer.start();
-        _ = try plugin.call("count_vowels", input);
+        var out = try plugin.call("count_vowels", input);
+        for (out) |_| { // this is really not a fair comparison, but whatever we're just trying
+            wasm_count += 1;
+        }
         wasm_elapsed += call_start.read();
     }
     const wasm_avg = wasm_elapsed / i;


### PR DESCRIPTION
don't merge this, just trying a zig test

i'd expect the compiler to optimize this away since we get back a const u8 array and the loop just increments 1 per iteration.. but I'm trying to get the wasm time and native time closer as it doesn't make much sense that wasm is executing faster here