### PR TITLE
refactor: Update dependencies in java maven module and cleanup code

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -51,16 +51,19 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- dependencies -->
-    <jna.version>5.12.1</jna.version>
-    <gson.version>2.10</gson.version>
+    <jna.version>5.13.0</jna.version>
+    <gson.version>2.10.1</gson.version>
 
     <!-- testing -->
-    <junit-jupiter-engine.version>5.9.1</junit-jupiter-engine.version>
-    <assertj-core.version>3.23.1</assertj-core.version>
+    <junit-jupiter-engine.version>5.9.3</junit-jupiter-engine.version>
+    <assertj-core.version>3.24.2</assertj-core.version>
 
     <!-- maven plugins -->
-    <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
-    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+    <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
+    <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+    <jreleaser-maven-plugin.version>1.8.0</jreleaser-maven-plugin.version>
 
     <!-- jreleaser -->
     <jreleaser.git.root.search>true</jreleaser.git.root.search>
@@ -74,7 +77,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.4.1</version>
+            <version>${maven-javadoc-plugin.version}</version>
             <configuration>
               <additionalJOption>-Xdoclint:none</additionalJOption>
             </configuration>
@@ -90,7 +93,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.2.1</version>
+            <version>${maven-source-plugin.version}</version>
             <executions>
               <execution>
                 <id>attach-source</id>
@@ -103,7 +106,7 @@
           <plugin>
             <groupId>org.jreleaser</groupId>
             <artifactId>jreleaser-maven-plugin</artifactId>
-            <version>1.3.1</version>
+            <version>${jreleaser-maven-plugin.version}</version>
             <configuration>
               <jreleaser>
                 <release>
@@ -181,13 +184,6 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>${assertj-core.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>uk.org.webcompere</groupId>
-      <artifactId>model-assert</artifactId>
-      <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/src/main/java/org/extism/sdk/CancelHandle.java
+++ b/java/src/main/java/org/extism/sdk/CancelHandle.java
@@ -6,7 +6,8 @@ import com.sun.jna.Pointer;
  * CancelHandle is used to cancel a running Plugin
  */
 public class CancelHandle {
-    private Pointer handle;
+
+    private final Pointer handle;
 
     public CancelHandle(Pointer handle) {
         this.handle = handle;
@@ -15,7 +16,7 @@ public class CancelHandle {
     /**
      * Cancel execution of the Plugin associated with the CancelHandle
      */
-    boolean cancel() {
+    public boolean cancel() {
         return LibExtism.INSTANCE.extism_plugin_cancel(this.handle);
     }
 }

--- a/java/src/main/java/org/extism/sdk/ExtismCurrentPlugin.java
+++ b/java/src/main/java/org/extism/sdk/ExtismCurrentPlugin.java
@@ -5,7 +5,8 @@ import com.sun.jna.Pointer;
 import java.nio.charset.StandardCharsets;
 
 public class ExtismCurrentPlugin {
-    public Pointer pointer;
+
+    private final Pointer pointer;
 
     public ExtismCurrentPlugin(Pointer pointer) {
         this.pointer = pointer;

--- a/java/src/main/java/org/extism/sdk/manifest/Manifest.java
+++ b/java/src/main/java/org/extism/sdk/manifest/Manifest.java
@@ -8,21 +8,41 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * The `Manifest` type is used to configure the runtime and specify how to load modules.
+ */
 public class Manifest {
 
+    /**
+     * Holds the WebAssembly modules, the `main` module should be named `main` or listed last.
+     */
     @SerializedName("wasm")
     private final List<WasmSource> sources;
 
+    /**
+     * Holds the memory options
+     */
     @SerializedName("memory")
     private final MemoryOptions memoryOptions;
 
+    /**
+     * Specifies which hosts may be accessed via HTTP, if this is empty then no hosts may be accessed. Wildcards may be used.
+     */
     // FIXME remove this and related stuff if not supported in java-sdk
     @SerializedName("allowed_hosts")
     private final List<String> allowedHosts;
 
+    /**
+     *  Specifies which paths should be made available on disk when using WASI.
+     *  This is a mapping from the path on disk to the path it should be available inside the plugin.
+     *  For example, `".": "/tmp"` would mount the current directory as `/tmp` inside the module
+     */
     @SerializedName("allowed_paths")
     private final Map<String, String> allowedPaths;
 
+    /**
+     * Config values are made accessible using the PDK `extism_config_get` function
+     */
     @SerializedName("config")
     private final Map<String, String> config;
 

--- a/java/src/main/java/org/extism/sdk/manifest/MemoryOptions.java
+++ b/java/src/main/java/org/extism/sdk/manifest/MemoryOptions.java
@@ -5,10 +5,12 @@ import com.google.gson.annotations.SerializedName;
 /**
  * Configures memory for the Wasm runtime.
  * Memory is described in units of pages (64KB) and represent contiguous chunks of addressable memory.
- *
- * @param max Max number of pages.
  */
 public class MemoryOptions {
+
+    /**
+     * The max number of WebAssembly pages that should be allocated for the module.
+     */
     @SerializedName("max")
     private final Integer max;
 

--- a/java/src/main/java/org/extism/sdk/support/JsonSerde.java
+++ b/java/src/main/java/org/extism/sdk/support/JsonSerde.java
@@ -1,14 +1,16 @@
 package org.extism.sdk.support;
 
-import com.google.gson.*;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import org.extism.sdk.manifest.Manifest;
 
 import java.io.IOException;
-import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 public class JsonSerde {


### PR DESCRIPTION
- Update maven-plugins in pom.xml
- Update dependency versions in pom.xml
- Remove model-assert (test) dependency to avoid using libraries with knwon CVEs
- Replaced model-assert with assertj+gson
- Removed unused imports
- Made pointer field in ExtismCurrentPlugin private final
- Made handle field in CancelHandle private final and exposed the cancel method (since it is a public type)