### PR TITLE
refactor!: Cleanup UserData implementation, update example in README

### DIFF
--- a/c/main.c
+++ b/c/main.c
@@ -64,8 +64,8 @@ int main(int argc, char *argv[]) {
                           "Hello, again!", free_data);
 
   char *errmsg = NULL;
-  ExtismPlugin *plugin =
-      extism_plugin_new(data, len, (ExtismFunction **)&f, 1, true, &errmsg);
+  ExtismPlugin *plugin = extism_plugin_new(
+      data, len, (const ExtismFunction **)&f, 1, true, &errmsg);
   free(data);
   if (plugin == NULL) {
     puts(errmsg);
@@ -79,8 +79,9 @@ int main(int argc, char *argv[]) {
   const uint8_t *output = extism_plugin_output_data(plugin);
   write(STDOUT_FILENO, output, out_len);
   write(STDOUT_FILENO, "\n", 1);
-  puts("Free plugin");
+  puts("Freeing plugin");
   extism_plugin_free(plugin);
+  puts("Freeing function");
   extism_function_free(f);
   return 0;
 }

--- a/c/main.c
+++ b/c/main.c
@@ -24,6 +24,8 @@ void hello_world(ExtismCurrentPlugin *plugin, const ExtismVal *inputs,
   outputs[0].v.i64 = inputs[0].v.i64;
 }
 
+void free_data(void *x) { puts("FREE"); }
+
 uint8_t *read_file(const char *filename, size_t *len) {
 
   FILE *fp = fopen(filename, "rb");
@@ -57,12 +59,13 @@ int main(int argc, char *argv[]) {
   uint8_t *data = read_file("../wasm/code-functions.wasm", &len);
   ExtismValType inputs[] = {I64};
   ExtismValType outputs[] = {I64};
-  ExtismFunction *f = extism_function_new("hello_world", inputs, 1, outputs, 1,
-                                          hello_world, "Hello, again!", NULL);
+  ExtismFunction *f =
+      extism_function_new("hello_world", inputs, 1, outputs, 1, hello_world,
+                          "Hello, again!", free_data);
 
   char *errmsg = NULL;
-  ExtismPlugin *plugin = extism_plugin_new(
-      data, len, (const ExtismFunction **)&f, 1, true, &errmsg);
+  ExtismPlugin *plugin =
+      extism_plugin_new(data, len, (ExtismFunction **)&f, 1, true, &errmsg);
   free(data);
   if (plugin == NULL) {
     puts(errmsg);
@@ -76,6 +79,8 @@ int main(int argc, char *argv[]) {
   const uint8_t *output = extism_plugin_output_data(plugin);
   write(STDOUT_FILENO, output, out_len);
   write(STDOUT_FILENO, "\n", 1);
+  puts("Free plugin");
   extism_plugin_free(plugin);
+  extism_function_free(f);
   return 0;
 }

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -189,10 +189,12 @@ fn main() {
         .build()
         .unwrap();
 
-    let res = plugin
-        .call::<&str, &str>("count_vowels", "Hello, world!")
-        .unwrap();
-    println!("{}", res);
+    for _ in 0 .. 5 {
+        let res = plugin
+            .call::<&str, &str>("count_vowels", "Hello, world!")
+            .unwrap();
+        println!("{}", res);
+    }
 }
 ```
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -176,20 +176,20 @@ fn main() {
             "kv_read",
             [ValType::I64],
             [ValType::I64],
-            Some(kv_store.clone()),
+            kv_store.clone(),
             kv_read,
         )
         .with_function(
             "kv_write",
             [ValType::I64, ValType::I64],
             [],
-            Some(kv_store),
+            kv_store.clone(),
             kv_write,
         )
         .build()
         .unwrap();
 
-    for _ in 0 .. 5 {
+    for _ in 0..5 {
         let res = plugin
             .call::<&str, &str>("count_vowels", "Hello, world!")
             .unwrap();

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -194,7 +194,6 @@ fn main() {
         .unwrap();
     println!("{}", res);
 }
-}
 ```
 
 > *Note*: In order to write host functions you should get familiar with the methods on the [Extism::CurrentPlugin](https://docs.rs/extism/latest/extism/struct.CurrentPlugin.html) and [Extism::CurrentPlugin](https://docs.rs/extism/latest/extism/struct.UserData.html) types.

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -147,7 +147,7 @@ type KVStore = std::collections::BTreeMap<String, Vec<u8>>;
 // When a first argument separated with a semicolon is provided to `host_fn` it is used as the
 // variable name and type for the `UserData` parameter
 host_fn!(kv_read(user_data: KVStore; key: String) -> u32 {
-    let kv = user_data.get().unwrap();
+    let kv = user_data.get()?;
     let kv = kv.lock().unwrap();
     let value = kv
         .get(&key)
@@ -157,7 +157,7 @@ host_fn!(kv_read(user_data: KVStore; key: String) -> u32 {
 });
 
 host_fn!(kv_write(user_data: KVStore; key: String, value: u32) {
-    let kv = user_data.get().unwrap();
+    let kv = user_data.get()?;
     let mut kv = kv.lock().unwrap();
     kv.insert(key, value.to_le_bytes().to_vec());
     Ok(())

--- a/runtime/benches/bench.rs
+++ b/runtime/benches/bench.rs
@@ -63,7 +63,7 @@ pub fn reflect_1(c: &mut Criterion) {
             "host_reflect",
             [ValType::I64],
             [ValType::I64],
-            None,
+            UserData::default(),
             hello_world,
         )
         .build()
@@ -87,7 +87,7 @@ pub fn reflect_10(c: &mut Criterion) {
             "host_reflect",
             [ValType::I64],
             [ValType::I64],
-            None,
+            UserData::default(),
             hello_world,
         )
         .build()
@@ -111,7 +111,7 @@ pub fn reflect_100(c: &mut Criterion) {
             "host_reflect",
             [ValType::I64],
             [ValType::I64],
-            None,
+            UserData::default(),
             hello_world,
         )
         .build()

--- a/runtime/examples/readme.rs
+++ b/runtime/examples/readme.rs
@@ -48,8 +48,10 @@ fn main() {
         .build()
         .unwrap();
 
-    let res = plugin
-        .call::<&str, &str>("count_vowels", "Hello, world!")
-        .unwrap();
-    println!("{}", res);
+    for _ in 0..5 {
+        let res = plugin
+            .call::<&str, &str>("count_vowels", "Hello, world!")
+            .unwrap();
+        println!("{}", res);
+    }
 }

--- a/runtime/examples/readme.rs
+++ b/runtime/examples/readme.rs
@@ -1,0 +1,55 @@
+use extism::*;
+
+// pretend this is redis or something :)
+type KVStore = std::collections::BTreeMap<String, Vec<u8>>;
+
+// When a first argument separated with a semicolon is provided to `host_fn` it is used as the
+// variable name and type for the `UserData` parameter
+host_fn!(kv_read(user_data: KVStore; key: String) -> u32 {
+    let kv = user_data.get().unwrap();
+    let kv = kv.lock().unwrap();
+    let value = kv
+        .get(&key)
+        .map(|x| u32::from_le_bytes(x.clone().try_into().unwrap()))
+        .unwrap_or_else(|| 0u32);
+    Ok(value)
+});
+
+host_fn!(kv_write(user_data: KVStore; key: String, value: u32) {
+    let kv = user_data.get().unwrap();
+    let mut kv = kv.lock().unwrap();
+    kv.insert(key, value.to_le_bytes().to_vec());
+    Ok(())
+});
+
+fn main() {
+    let kv_store = UserData::new(KVStore::default());
+
+    let url = Wasm::url(
+        "https://github.com/extism/plugins/releases/latest/download/count_vowels_kvstore.wasm",
+    );
+    let manifest = Manifest::new([url]);
+    let mut plugin = PluginBuilder::new(manifest)
+        .with_wasi(true)
+        .with_function(
+            "kv_read",
+            [ValType::I64],
+            [ValType::I64],
+            Some(kv_store.clone()),
+            kv_read,
+        )
+        .with_function(
+            "kv_write",
+            [ValType::I64, ValType::I64],
+            [],
+            Some(kv_store),
+            kv_write,
+        )
+        .build()
+        .unwrap();
+
+    let res = plugin
+        .call::<&str, &str>("count_vowels", "Hello, world!")
+        .unwrap();
+    println!("{}", res);
+}

--- a/runtime/examples/readme.rs
+++ b/runtime/examples/readme.rs
@@ -35,14 +35,14 @@ fn main() {
             "kv_read",
             [ValType::I64],
             [ValType::I64],
-            Some(kv_store.clone()),
+            kv_store.clone(),
             kv_read,
         )
         .with_function(
             "kv_write",
             [ValType::I64, ValType::I64],
             [],
-            Some(kv_store),
+            kv_store.clone(),
             kv_write,
         )
         .build()

--- a/runtime/examples/readme.rs
+++ b/runtime/examples/readme.rs
@@ -6,7 +6,7 @@ type KVStore = std::collections::BTreeMap<String, Vec<u8>>;
 // When a first argument separated with a semicolon is provided to `host_fn` it is used as the
 // variable name and type for the `UserData` parameter
 host_fn!(kv_read(user_data: KVStore; key: String) -> u32 {
-    let kv = user_data.get().unwrap();
+    let kv = user_data.get()?;
     let kv = kv.lock().unwrap();
     let value = kv
         .get(&key)
@@ -16,7 +16,7 @@ host_fn!(kv_read(user_data: KVStore; key: String) -> u32 {
 });
 
 host_fn!(kv_write(user_data: KVStore; key: String, value: u32) {
-    let kv = user_data.get().unwrap();
+    let kv = user_data.get()?;
     let mut kv = kv.lock().unwrap();
     kv.insert(key, value.to_le_bytes().to_vec());
     Ok(())

--- a/runtime/extism.h
+++ b/runtime/extism.h
@@ -55,9 +55,6 @@ typedef struct ExtismCancelHandle ExtismCancelHandle;
  */
 typedef struct ExtismCurrentPlugin ExtismCurrentPlugin;
 
-/**
- * Wraps raw host functions with some additional metadata and user data
- */
 typedef struct ExtismFunction ExtismFunction;
 
 /**
@@ -163,7 +160,7 @@ void extism_function_free(ExtismFunction *f);
 void extism_function_set_namespace(ExtismFunction *ptr, const char *namespace_);
 
 /**
- * Create a new plugin with additional host functions
+ * Create a new plugin with host functions, the functions passed to this function no longer need to be manually freed using
  *
  * `wasm`: is a WASM module (wat or wasm) or a JSON encoded manifest
  * `wasm_size`: the length of the `wasm` parameter
@@ -173,7 +170,7 @@ void extism_function_set_namespace(ExtismFunction *ptr, const char *namespace_);
  */
 ExtismPlugin *extism_plugin_new(const uint8_t *wasm,
                                 ExtismSize wasm_size,
-                                const ExtismFunction **functions,
+                                ExtismFunction **functions,
                                 ExtismSize n_functions,
                                 bool with_wasi,
                                 char **errmsg);

--- a/runtime/extism.h
+++ b/runtime/extism.h
@@ -170,7 +170,7 @@ void extism_function_set_namespace(ExtismFunction *ptr, const char *namespace_);
  */
 ExtismPlugin *extism_plugin_new(const uint8_t *wasm,
                                 ExtismSize wasm_size,
-                                ExtismFunction **functions,
+                                const ExtismFunction **functions,
                                 ExtismSize n_functions,
                                 bool with_wasi,
                                 char **errmsg);

--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -259,8 +259,8 @@ impl CurrentPlugin {
     /// Get a pointer to the plugin memory
     pub(crate) fn memory_ptr(&mut self) -> *mut u8 {
         if let Some(mem) = self.memory() {
-            let (_, mut store) = self.linker_and_store();
-            return mem.data_ptr(&mut store);
+            let (_, store) = self.linker_and_store();
+            return mem.data_ptr(store);
         }
 
         std::ptr::null_mut()
@@ -325,7 +325,7 @@ impl CurrentPlugin {
     pub fn set_error(&mut self, s: impl AsRef<str>) -> Result<(u64, u64), Error> {
         let s = s.as_ref();
         debug!("Set error: {:?}", s);
-        let handle = self.current_plugin_mut().memory_new(&s)?;
+        let handle = self.current_plugin_mut().memory_new(s)?;
         let (linker, mut store) = self.linker_and_store();
         if let Some(f) = linker.get(&mut store, "env", "extism_error_set") {
             f.into_func().unwrap().call(
@@ -333,7 +333,7 @@ impl CurrentPlugin {
                 &[Val::I64(handle.offset() as i64)],
                 &mut [],
             )?;
-            return Ok((handle.offset(), s.len() as u64));
+            Ok((handle.offset(), s.len() as u64))
         } else {
             anyhow::bail!("extism_error_set not found");
         }

--- a/runtime/src/function.rs
+++ b/runtime/src/function.rs
@@ -127,13 +127,12 @@ impl<T> Default for UserData<T> {
 
 impl<T> Drop for UserData<T> {
     fn drop(&mut self) {
-        match self {
-            UserData::C { ptr, free } => {
-                if let Some(free) = free {
-                    free(*ptr);
-                }
-            }
-            _ => (),
+        if let UserData::C {
+            ptr,
+            free: Some(free),
+        } = self
+        {
+            free(*ptr);
         }
     }
 }

--- a/runtime/src/function.rs
+++ b/runtime/src/function.rs
@@ -76,7 +76,6 @@ impl<T> Clone for UserData<T> {
                 ptr: *ptr,
                 free: None,
             },
-            // UserData::Ref(ptr) => UserData::Ref(ptr.clone()),
             UserData::Rust(data) => UserData::Rust(data.clone()),
         }
     }
@@ -112,10 +111,6 @@ impl<T> UserData<T> {
     pub fn get(&self) -> Option<std::sync::Arc<std::sync::Mutex<T>>> {
         match self {
             UserData::C { .. } => None,
-            // UserData::Ref(UserDataPointer { ptr, .. }) => {
-            //     let ptr = unsafe { &*(*ptr as *mut UserData<T>) };
-            //     ptr.get()
-            // }
             UserData::Rust(data) => Some(data.clone()),
         }
     }

--- a/runtime/src/function.rs
+++ b/runtime/src/function.rs
@@ -95,7 +95,10 @@ impl<T> UserData<T> {
     pub(crate) fn as_ptr(&self) -> *mut std::ffi::c_void {
         match self {
             UserData::C { ptr, .. } => *ptr,
-            _ => std::ptr::null_mut(),
+            _ => {
+                log::error!("Rust UserData cannot be used by C");
+                std::ptr::null_mut()
+            }
         }
     }
 

--- a/runtime/src/function.rs
+++ b/runtime/src/function.rs
@@ -1,3 +1,5 @@
+use wasmtime::Caller;
+
 use crate::{CurrentPlugin, Error};
 
 /// An enumeration of all possible value types in WebAssembly.
@@ -57,123 +59,95 @@ pub type Val = wasmtime::Val;
 
 /// UserData is an opaque pointer used to store additional data
 /// that gets passed into host function callbacks
-pub struct UserData {
-    ptr: *mut std::ffi::c_void,
-    free: Option<extern "C" fn(_: *mut std::ffi::c_void)>,
-    is_any: bool,
+#[derive(Debug)]
+pub enum UserData<T: Sized> {
+    C {
+        ptr: *mut std::ffi::c_void,
+        free: Option<extern "C" fn(_: *mut std::ffi::c_void)>,
+    },
+    // Ref(UserDataPointer),
+    Rust(std::sync::Arc<std::sync::Mutex<T>>),
 }
 
-extern "C" fn free_any(ptr: *mut std::ffi::c_void) {
-    let ptr = ptr as *mut dyn std::any::Any;
-    unsafe { drop(Box::from_raw(ptr)) }
+impl<T> Clone for UserData<T> {
+    fn clone(&self) -> Self {
+        match self {
+            UserData::C { ptr, .. } => UserData::C {
+                ptr: *ptr,
+                free: None,
+            },
+            // UserData::Ref(ptr) => UserData::Ref(ptr.clone()),
+            UserData::Rust(data) => UserData::Rust(data.clone()),
+        }
+    }
 }
 
-impl UserData {
+impl<T> UserData<T> {
     /// Create a new `UserData` from an existing pointer and free function, this is used
     /// by the C API to wrap C pointers into user data
     pub(crate) fn new_pointer(
         ptr: *mut std::ffi::c_void,
         free: Option<extern "C" fn(_: *mut std::ffi::c_void)>,
     ) -> Self {
-        UserData {
-            ptr,
-            free,
-            is_any: false,
+        UserData::C { ptr, free }
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut std::ffi::c_void {
+        match self {
+            UserData::C { ptr, .. } => *ptr,
+            _ => std::ptr::null_mut(),
         }
     }
 
     /// Create a new `UserData` with any Rust type
-    pub fn new<T: std::any::Any>(x: T) -> Self {
-        let ptr = Box::into_raw(Box::new(x)) as *mut _;
-        UserData {
-            ptr,
-            free: Some(free_any),
-            is_any: true,
-        }
-    }
-
-    /// Returns `true` if the underlying pointer is `null`
-    pub fn is_null(&self) -> bool {
-        self.ptr.is_null()
-    }
-
-    /// Get the user data pointer
-    pub(crate) fn as_ptr(&self) -> *mut std::ffi::c_void {
-        self.ptr
-    }
-
-    pub(crate) fn make_copy(&self) -> Self {
-        UserData {
-            ptr: self.ptr,
-            free: None,
-            is_any: self.is_any,
-        }
-    }
-
-    /// Get the pointer as an `Any` value - this will only return `Some` if `UserData::new` was used to create the value,
-    /// when `UserData::new_pointer` is used there is no way to know the original type of the pointer
-    pub fn any(&self) -> Option<&dyn std::any::Any> {
-        if !self.is_any || self.is_null() {
-            return None;
-        }
-
-        unsafe { Some(&*self.ptr) }
+    pub fn new(x: T) -> Self {
+        let data = std::sync::Arc::new(std::sync::Mutex::new(x));
+        UserData::Rust(data)
     }
 
     /// Get a reference to the value stored in `UserData` if it matches the initial type    
-    pub fn get<T: 'static>(&self) -> Option<&T> {
-        self.any().and_then(|x| x.downcast_ref())
-    }
-
-    /// Get the pointer as a mutable `Any` value - this will only return `Some` if `UserData::new` was used to create the value,
-    /// when `UserData::new_pointer` is used there is no way to know the original type of the pointer
-    pub fn any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
-        if !self.is_any || self.is_null() {
-            return None;
+    pub fn get(&self) -> Option<std::sync::Arc<std::sync::Mutex<T>>> {
+        match self {
+            UserData::C { .. } => None,
+            // UserData::Ref(UserDataPointer { ptr, .. }) => {
+            //     let ptr = unsafe { &*(*ptr as *mut UserData<T>) };
+            //     ptr.get()
+            // }
+            UserData::Rust(data) => Some(data.clone()),
         }
-
-        unsafe { Some(&mut *self.ptr) }
-    }
-
-    /// Get a mutable reference to the value stored in `UserData` if it matches the initial type    
-    pub fn get_mut<T: 'static>(&mut self) -> Option<&mut T> {
-        self.any_mut().and_then(|x| x.downcast_mut())
     }
 }
 
-impl Default for UserData {
+impl<T> Default for UserData<T> {
     fn default() -> Self {
-        UserData {
+        UserData::C {
             ptr: std::ptr::null_mut(),
             free: None,
-            is_any: false,
         }
     }
 }
 
-impl Drop for UserData {
+impl<T> Drop for UserData<T> {
     fn drop(&mut self) {
-        if self.ptr.is_null() {
-            return;
+        match self {
+            UserData::C { ptr, free } => {
+                if let Some(free) = free {
+                    free(*ptr);
+                }
+            }
+            _ => (),
         }
-
-        if let Some(free) = self.free {
-            free(self.ptr);
-        }
-
-        self.ptr = std::ptr::null_mut();
     }
 }
 
-unsafe impl Send for UserData {}
-unsafe impl Sync for UserData {}
+unsafe impl<T> Send for UserData<T> {}
+unsafe impl<T> Sync for UserData<T> {}
 
 type FunctionInner = dyn Fn(wasmtime::Caller<CurrentPlugin>, &[wasmtime::Val], &mut [wasmtime::Val]) -> Result<(), Error>
     + Sync
     + Send;
 
 /// Wraps raw host functions with some additional metadata and user data
-#[derive(Clone)]
 pub struct Function {
     /// Function name
     pub(crate) name: String,
@@ -188,37 +162,54 @@ pub struct Function {
     pub(crate) f: std::sync::Arc<FunctionInner>,
 
     /// UserData
-    pub(crate) _user_data: std::sync::Arc<UserData>,
+    pub(crate) _user_data: std::sync::Arc<std::sync::Mutex<dyn std::any::Any>>,
+}
+
+impl Clone for Function {
+    fn clone(&self) -> Self {
+        Function {
+            name: self.name.clone(),
+            namespace: self.namespace.clone(),
+            ty: self.ty.clone(),
+            f: self.f.clone(),
+            _user_data: self._user_data.clone(),
+        }
+    }
 }
 
 impl Function {
     /// Create a new host function
-    pub fn new<F>(
+    pub fn new<T: 'static, F>(
         name: impl Into<String>,
         args: impl IntoIterator<Item = ValType>,
         returns: impl IntoIterator<Item = ValType>,
-        user_data: Option<UserData>,
+        user_data: Option<UserData<T>>,
         f: F,
     ) -> Function
     where
         F: 'static
-            + Fn(&mut CurrentPlugin, &[Val], &mut [Val], UserData) -> Result<(), Error>
+            + Fn(&mut CurrentPlugin, &[Val], &mut [Val], UserData<T>) -> Result<(), Error>
             + Sync
             + Send,
     {
         let user_data = user_data.unwrap_or_default();
-        let data = user_data.make_copy();
+        let data = user_data.clone();
         Function {
             name: name.into(),
             ty: wasmtime::FuncType::new(
                 args.into_iter().map(wasmtime::ValType::from),
                 returns.into_iter().map(wasmtime::ValType::from),
             ),
-            f: std::sync::Arc::new(move |mut caller, inp, outp| {
-                f(caller.data_mut(), inp, outp, data.make_copy())
-            }),
+            f: std::sync::Arc::new(
+                move |mut caller: Caller<_>, inp: &[Val], outp: &mut [Val]| {
+                    let x = data.clone();
+                    f(caller.data_mut(), inp, outp, x)
+                },
+            ),
             namespace: None,
-            _user_data: std::sync::Arc::new(user_data),
+            _user_data: user_data
+                .get()
+                .expect("Function::new should not be called with C-created user-data"),
         }
     }
 
@@ -254,25 +245,25 @@ impl Function {
 /// For example, the following defines a host function named `add_newline` that takes a
 /// string parameter and returns a string result:
 /// ```rust
-/// extism::host_fn!(add_newline(_user_data, a: String) -> String { Ok(a + "\n") });
+/// extism::host_fn!(add_newline(_user_data: (), a: String) -> String { Ok(a + "\n") });
 /// ```
 /// A few things worth noting:
 /// - The function always returns a `Result` that wraps the specified return type
-/// - If an untyped first parameter is passed (`_user_data` above) it will be
+/// - If a first parameter and type are passed (`_user_data` above) followed by a semicolon it will be
 ///    the name of the `UserData` parameter and can be used from inside the function
 //     definition.
 #[macro_export]
 macro_rules! host_fn {
     ($name: ident  ($($arg:ident : $argty:ty),*) $(-> $ret:ty)? $b:block) => {
-        $crate::host_fn!($name (user_data, $($arg : $argty),*) $(-> $ret)? {$b});
+        $crate::host_fn!($name (user_data: (); $($arg : $argty),*) $(-> $ret)? {$b});
     };
-    ($name: ident  ($user_data:ident, $($arg:ident : $argty:ty),*) $(-> $ret:ty)? $b:block) => {
+    ($name: ident  ($user_data:ident : $dataty:ty; $($arg:ident : $argty:ty),*) $(-> $ret:ty)? $b:block) => {
         fn $name(
             plugin: &mut $crate::CurrentPlugin,
             inputs: &[$crate::Val],
             outputs: &mut [$crate::Val],
             #[allow(unused)]
-            mut $user_data: $crate::UserData,
+            mut $user_data: $crate::UserData<$dataty>,
         ) -> Result<(), $crate::Error> {
             let mut index = 0;
             $(
@@ -284,7 +275,9 @@ macro_rules! host_fn {
             )*
             let output = move || -> Result<_, $crate::Error> { $b };
             let output: $crate::convert::MemoryHandle = plugin.memory_new(&output()?)?;
-            outputs[0] = plugin.memory_to_val(output);
+            if !outputs.is_empty() {
+                outputs[0] = plugin.memory_to_val(output);
+            }
             Ok(())
         }
     };

--- a/runtime/src/function.rs
+++ b/runtime/src/function.rs
@@ -138,9 +138,9 @@ impl<T> UserData<T> {
 
 impl Drop for CPtr {
     fn drop(&mut self) {
-        if self.ptr.is_null() {
-            if let Some(free) = &self.free {
-                free(self.ptr);
+        if !self.ptr.is_null() {
+            if let Some(free_data) = &self.free {
+                free_data(self.ptr);
                 self.ptr = std::ptr::null_mut();
             }
         }

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -160,7 +160,7 @@ impl Plugin {
         let profiling_strategy = debug_options
             .profiling_strategy
             .map_or(ProfilingStrategy::None, |_| profiling_strategy());
-        debug_options.profiling_strategy = Some(profiling_strategy.clone());
+        debug_options.profiling_strategy = Some(profiling_strategy);
 
         // Setup wasmtime types
         let engine = Engine::new(
@@ -663,7 +663,7 @@ impl Plugin {
                     if let Some(memory) = self.current_plugin_mut().memory() {
                         debug!("Dumping memory to {}", file.display());
                         let data = memory.data(&mut self.store);
-                        if let Err(e) = std::fs::write(file, &data) {
+                        if let Err(e) = std::fs::write(file, data) {
                             error!("Unable to write memory dump: {:?}", e);
                         }
                     } else {
@@ -703,10 +703,10 @@ impl Plugin {
                 }
 
                 error!("Call to {name} encountered an error: {e:?}");
-                return Err((
+                Err((
                     e.context(msg.unwrap_or_else(|| "Error in Extism plugin call".to_string())),
                     -1,
-                ));
+                ))
             }
         }
     }

--- a/runtime/src/plugin_builder.rs
+++ b/runtime/src/plugin_builder.rs
@@ -54,7 +54,7 @@ impl PluginBuilder {
         name: impl Into<String>,
         args: impl IntoIterator<Item = ValType>,
         returns: impl IntoIterator<Item = ValType>,
-        user_data: Option<UserData<T>>,
+        user_data: UserData<T>,
         f: F,
     ) -> Self
     where
@@ -75,7 +75,7 @@ impl PluginBuilder {
         name: impl Into<String>,
         args: impl IntoIterator<Item = ValType>,
         returns: impl IntoIterator<Item = ValType>,
-        user_data: Option<UserData<T>>,
+        user_data: UserData<T>,
         f: F,
     ) -> Self
     where

--- a/runtime/src/plugin_builder.rs
+++ b/runtime/src/plugin_builder.rs
@@ -120,7 +120,7 @@ impl PluginBuilder {
         match self.source {
             Source::Manifest(m) => {
                 let data = serde_json::to_vec(&m)?;
-                Plugin::build_new(&data, self.functions, self.wasi, self.debug_options)
+                Plugin::build_new(data, self.functions, self.wasi, self.debug_options)
             }
             Source::Data(d) => Plugin::build_new(d, self.functions, self.wasi, self.debug_options),
         }

--- a/runtime/src/plugin_builder.rs
+++ b/runtime/src/plugin_builder.rs
@@ -49,27 +49,43 @@ impl PluginBuilder {
     }
 
     /// Add a single host function
-    pub fn with_function<F>(
+    pub fn with_function<T: 'static, F>(
         mut self,
         name: impl Into<String>,
         args: impl IntoIterator<Item = ValType>,
         returns: impl IntoIterator<Item = ValType>,
-        user_data: Option<UserData>,
+        user_data: Option<UserData<T>>,
         f: F,
     ) -> Self
     where
         F: 'static
-            + Fn(&mut CurrentPlugin, &[Val], &mut [Val], UserData) -> Result<(), Error>
+            + Fn(&mut CurrentPlugin, &[Val], &mut [Val], UserData<T>) -> Result<(), Error>
             + Sync
             + Send,
     {
-        self.functions.push(Function::new(
-            name,
-            args,
-            returns,
-            user_data.map(UserData::new),
-            f,
-        ));
+        self.functions
+            .push(Function::new(name, args, returns, user_data, f));
+        self
+    }
+
+    /// Add a single host function in a specific namespace
+    pub fn with_function_in_namespace<T: 'static, F>(
+        mut self,
+        namespace: impl Into<String>,
+        name: impl Into<String>,
+        args: impl IntoIterator<Item = ValType>,
+        returns: impl IntoIterator<Item = ValType>,
+        user_data: Option<UserData<T>>,
+        f: F,
+    ) -> Self
+    where
+        F: 'static
+            + Fn(&mut CurrentPlugin, &[Val], &mut [Val], UserData<T>) -> Result<(), Error>
+            + Sync
+            + Send,
+    {
+        self.functions
+            .push(Function::new(name, args, returns, user_data, f).with_namespace(namespace));
         self
     }
 

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -190,7 +190,7 @@ pub unsafe extern "C" fn extism_function_new(
     }
     .to_vec();
 
-    let user_data = UserData::new_pointer(user_data, free_user_data);
+    let user_data: UserData<()> = UserData::new_pointer(user_data, free_user_data);
     let f = Function::new(
         name,
         inputs,
@@ -277,7 +277,7 @@ pub unsafe extern "C" fn extism_plugin_new(
                 if f.is_null() {
                     continue;
                 }
-                let f = (*f).clone();
+                let f = (&*f).clone();
                 funcs.push(f);
             }
         }

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -195,7 +195,7 @@ pub unsafe extern "C" fn extism_function_new(
         name,
         inputs,
         output_types.clone(),
-        Some(user_data),
+        user_data,
         move |plugin, inputs, outputs, user_data| {
             let inputs: Vec<_> = inputs.iter().map(ExtismVal::from).collect();
             let mut output_tmp: Vec<_> = output_types

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -7,6 +7,7 @@ use crate::*;
 
 pub type ExtismMemoryHandle = u64;
 pub type Size = u64;
+pub struct ExtismFunction(Option<Function>);
 
 /// The return code used to specify a successful plugin call
 pub static EXTISM_SUCCESS: i32 = 0;
@@ -168,7 +169,7 @@ pub unsafe extern "C" fn extism_function_new(
     func: ExtismFunctionType,
     user_data: *mut std::ffi::c_void,
     free_user_data: Option<extern "C" fn(_: *mut std::ffi::c_void)>,
-) -> *mut Function {
+) -> *mut ExtismFunction {
     let name = match std::ffi::CStr::from_ptr(name).to_str() {
         Ok(x) => x.to_string(),
         Err(_) => {
@@ -227,30 +228,35 @@ pub unsafe extern "C" fn extism_function_new(
             Ok(())
         },
     );
-    Box::into_raw(Box::new(f))
+    Box::into_raw(Box::new(ExtismFunction(Some(f))))
 }
 
 /// Free `ExtismFunction`
 #[no_mangle]
-pub unsafe extern "C" fn extism_function_free(f: *mut Function) {
+pub unsafe extern "C" fn extism_function_free(f: *mut ExtismFunction) {
     if f.is_null() {
         return;
     }
+
     drop(Box::from_raw(f))
 }
 
 /// Set the namespace of an `ExtismFunction`
 #[no_mangle]
 pub unsafe extern "C" fn extism_function_set_namespace(
-    ptr: *mut Function,
+    ptr: *mut ExtismFunction,
     namespace: *const std::ffi::c_char,
 ) {
     let namespace = std::ffi::CStr::from_ptr(namespace);
     let f = &mut *ptr;
-    f.set_namespace(namespace.to_string_lossy().to_string());
+    if let Some(x) = &mut f.0 {
+        x.set_namespace(namespace.to_string_lossy().to_string());
+    } else {
+        debug!("Trying to set namespace of already registered function")
+    }
 }
 
-/// Create a new plugin with additional host functions
+/// Create a new plugin with host functions, the functions passed to this function no longer need to be manually freed using
 ///
 /// `wasm`: is a WASM module (wat or wasm) or a JSON encoded manifest
 /// `wasm_size`: the length of the `wasm` parameter
@@ -261,7 +267,7 @@ pub unsafe extern "C" fn extism_function_set_namespace(
 pub unsafe extern "C" fn extism_plugin_new(
     wasm: *const u8,
     wasm_size: Size,
-    functions: *mut *const Function,
+    functions: *const *mut ExtismFunction,
     n_functions: Size,
     with_wasi: bool,
     errmsg: *mut *mut std::ffi::c_char,
@@ -277,8 +283,15 @@ pub unsafe extern "C" fn extism_plugin_new(
                 if f.is_null() {
                     continue;
                 }
-                let f = (*f).clone();
-                funcs.push(f);
+                if let Some(f) = (*f).0.take() {
+                    funcs.push(f);
+                } else {
+                    let e = std::ffi::CString::new(
+                        "Function cannot be registered with multiple different Plugins",
+                    )
+                    .unwrap();
+                    *errmsg = e.into_raw();
+                }
             }
         }
     }

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -277,7 +277,7 @@ pub unsafe extern "C" fn extism_plugin_new(
                 if f.is_null() {
                     continue;
                 }
-                let f = (&*f).clone();
+                let f = (*f).clone();
                 funcs.push(f);
             }
         }

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -14,7 +14,7 @@ host_fn!(hello_world (a: String) -> String { Ok(a) });
 //     plugin: &mut CurrentPlugin,
 //     inputs: &[Val],
 //     outputs: &mut [Val],
-//     _user_data: UserData,
+//     _user_data: UserData<()>,
 // ) -> Result<(), Error> {
 //     let input: String = plugin.memory_get_val(&inputs[0]).unwrap();
 //     let output = plugin.memory_new(&input).unwrap();
@@ -44,7 +44,7 @@ fn it_works() {
         "hello_world",
         [ValType::I64],
         [ValType::I64],
-        None,
+        UserData::default(),
         hello_world,
     )
     .with_namespace("env");
@@ -52,7 +52,7 @@ fn it_works() {
         "hello_world",
         [ValType::I64],
         [ValType::I64],
-        None,
+        UserData::default(),
         hello_world_panic,
     )
     .with_namespace("test");
@@ -143,7 +143,7 @@ fn test_plugin_threads() {
                 "hello_world",
                 [ValType::I64],
                 [ValType::I64],
-                None,
+                UserData::default(),
                 hello_world,
             )
             .with_wasi(true)
@@ -176,7 +176,7 @@ fn test_cancel() {
         "hello_world",
         [ValType::I64],
         [ValType::I64],
-        None,
+        UserData::default(),
         hello_world,
     );
 
@@ -201,7 +201,7 @@ fn test_timeout() {
         "hello_world",
         [ValType::I64],
         [ValType::I64],
-        None,
+        UserData::default(),
         hello_world,
     );
 
@@ -234,7 +234,7 @@ fn test_typed_plugin_macro() {
         "hello_world",
         [ValType::I64],
         [ValType::I64],
-        None,
+        UserData::default(),
         hello_world,
     );
 
@@ -252,7 +252,7 @@ fn test_multiple_instantiations() {
         "hello_world",
         [ValType::I64],
         [ValType::I64],
-        None,
+        UserData::default(),
         hello_world,
     );
 
@@ -294,7 +294,7 @@ fn test_fuzz_reflect_plugin() {
         "host_reflect",
         [ValType::I64],
         [ValType::I64],
-        None,
+        UserData::default(),
         hello_world,
     );
 
@@ -353,7 +353,7 @@ fn test_extism_error() {
         "hello_world",
         [ValType::I64],
         [ValType::I64],
-        None,
+        UserData::default(),
         hello_world_set_error,
     );
     let mut plugin = Plugin::new_with_manifest(&manifest, [f], true).unwrap();
@@ -368,7 +368,7 @@ fn test_extism_memdump() {
         "hello_world",
         [ValType::I64],
         [ValType::I64],
-        None,
+        UserData::default(),
         hello_world_set_error,
     );
     let mut plugin = PluginBuilder::new_with_module(WASM)
@@ -389,7 +389,7 @@ fn test_extism_coredump() {
         "hello_world",
         [ValType::I64],
         [ValType::I64],
-        None,
+        UserData::default(),
         hello_world_set_error,
     );
     let manifest = Manifest::new([extism_manifest::Wasm::data(WASM_LOOP)])
@@ -432,7 +432,7 @@ fn test_userdata() {
             "hello_world",
             [ValType::I64],
             [ValType::I64],
-            Some(UserData::new(file)),
+            UserData::new(file),
             hello_world_user_data,
         );
         let mut plugin = PluginBuilder::new_with_module(WASM)

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -423,7 +423,7 @@ fn hello_world_user_data(
 #[test]
 fn test_userdata() {
     let path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("tmp");
-    {
+    let output = {
         if path.exists() {
             std::fs::remove_file(&path).unwrap();
         }
@@ -442,6 +442,8 @@ fn test_userdata() {
             .unwrap();
         let output: Result<String, Error> = plugin.call("count_vowels", "a".repeat(1024));
         assert!(output.is_ok());
-    }
+        output.unwrap()
+    };
     assert!(path.exists());
+    assert_eq!(std::fs::read(path).unwrap(), output.as_bytes());
 }


### PR DESCRIPTION
Fixes #545 

- Adds a type parameter to `UserData` type to avoid dynamic typing issues
- Adds KV example from README to `examples/readme.rs` to make sure it stays in-sync
- Implement `Default` for `UserData<T>` when `T` implements `Default`
- Make `UserData` argument non-optional in `Function::new`, `UserData::default()` can be used instead.