### PR TITLE
feat: build static libextism

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           - os: 'windows'
             target: 'x86_64-pc-windows-msvc'
             artifact: 'extism.dll'
-            static-artifact: 'libextism.lib'
+            static-artifact: 'extism.lib'
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,24 +27,31 @@ jobs:
           - os: 'macos'
             target: 'x86_64-apple-darwin'
             artifact: 'libextism.dylib'
+            static-artifact: 'libextism.a'
           - os: 'macos'
             target: 'aarch64-apple-darwin'
             artifact: 'libextism.dylib'
+            static-artifact: 'libextism.a'
           - os: 'ubuntu'
             target: 'aarch64-unknown-linux-gnu'
             artifact: 'libextism.so'
+            static-artifact: 'libextism.a'
           - os: 'ubuntu'
             target: 'aarch64-unknown-linux-musl'
             artifact: 'libextism.so'
+            static-artifact: 'libextism.a'
           - os: 'ubuntu'
             target: 'x86_64-unknown-linux-gnu'
             artifact: 'libextism.so'
+            static-artifact: 'libextism.a'
           - os: 'windows'
             target: 'x86_64-pc-windows-gnu'
             artifact: 'extism.dll'
+            static-artifact: 'libextism.a'
           - os: 'windows'
             target: 'x86_64-pc-windows-msvc'
             artifact: 'extism.dll'
+            static-artifact: 'libextism.lib'
 
     steps:
       - name: Checkout
@@ -122,7 +129,7 @@ jobs:
           # compress the shared library & create checksum
           cp runtime/extism.h ${SRC_DIR}
           cp LICENSE ${SRC_DIR}
-          tar -C ${SRC_DIR} -czvf ${ARCHIVE} ${{ matrix.artifact }} extism.h
+          tar -C ${SRC_DIR} -czvf ${ARCHIVE} ${{ matrix.artifact }} ${{ matrix.static-artifact }} extism.h
           ls -ll ${ARCHIVE}
 
           if &>/dev/null which shasum; then

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DEST?=/usr/local
 SOEXT=so
+AEXT=a
 FEATURES?=default
 DEFAULT_FEATURES?=yes
 
@@ -38,8 +39,9 @@ install:
 	mkdir -p $(DEST)/lib $(DEST)/include
 	install runtime/extism.h $(DEST)/include/extism.h
 	install target/release/libextism.$(SOEXT) $(DEST)/lib/libextism.$(SOEXT)
+	install target/release/libextism.$(AEXT) $(DEST)/lib/libextism.$(AEXT)
 
 uninstall:
-	rm -f $(DEST)/include/extism.h $(DEST)/lib/libextism.$(SOEXT)
+	rm -f $(DEST)/include/extism.h $(DEST)/lib/libextism.$(SOEXT) $(DEST)/lib/libextism.$(AEXT)
 
 

--- a/c/Makefile
+++ b/c/Makefile
@@ -1,2 +1,11 @@
+.PHONY: build
 build:
-	clang -g -o main main.c -lextism -L .
+	$(CC) -g -o main main.c -lextism -L .
+
+.PHONY: static
+static:
+	$(CC) -g -o main main.c -l:libextism.a -lm -L .
+
+.PHONY: clean
+clean:
+	rm -f main

--- a/libextism/Cargo.toml
+++ b/libextism/Cargo.toml
@@ -10,7 +10,7 @@ description = "libextism"
 
 [lib]
 name = "extism"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "staticlib"]
 doc = false
 
 [dependencies]


### PR DESCRIPTION
* libextism is now built to crate-type `staticlib` as recommend by @zshipko
* updated `Makefile` to install and uninstall the static library.
* updated c example to have `static` target to link libextism statically
    * Compiler is no longer hardcoded to `clang`. Set `CC` to use a compiler other than the system compiler. Tested with `gcc` and `clang`.
* added `static-artifact` to actions release. Untested as it's only ran on push with tag. 