### PR TITLE
fix: set epoch deadline before each plugin call

### DIFF
--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -590,6 +590,9 @@ impl Plugin {
                     .map(std::time::Duration::from_millis),
             })
             .unwrap();
+        self.store.set_epoch_deadline(1);
+        self.store
+            .epoch_deadline_callback(|_| Err(wasmtime::Trap::Interrupt.into()));
 
         // Call the function
         let mut results = vec![wasmtime::Val::null(); n_results];

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -180,6 +180,7 @@ impl Plugin {
             &engine,
             CurrentPlugin::new(manifest, with_wasi, available_pages)?,
         );
+        store.set_epoch_deadline(1);
 
         let mut linker = Linker::new(&engine);
         linker.allow_shadowing(true);
@@ -282,7 +283,7 @@ impl Plugin {
                     internal.available_pages,
                 )?,
             );
-
+            self.store.set_epoch_deadline(1);
             let store = &mut self.store as *mut _;
             let linker = &mut self.linker as *mut _;
             let current_plugin = self.current_plugin_mut();
@@ -590,8 +591,7 @@ impl Plugin {
                     .map(std::time::Duration::from_millis),
             })
             .expect("Timer should start");
-        self.store
-            .epoch_deadline_callback(|_| Err(wasmtime::Trap::Interrupt.into()));
+        self.store.epoch_deadline_trap();
         self.store.set_epoch_deadline(1);
 
         // Call the function

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn extism_current_plugin_memory_length(
     }
 
     let plugin = &mut *plugin;
-    plugin.memory_length(n)
+    plugin.memory_length(n).unwrap_or_default()
 }
 
 /// Free an allocated memory block
@@ -407,7 +407,7 @@ pub unsafe extern "C" fn extism_plugin_config(
         }
     }
 
-    plugin.clear_error();
+    let _ = plugin.clear_error();
     true
 }
 
@@ -434,7 +434,7 @@ pub unsafe extern "C" fn extism_plugin_function_exists(
         }
     };
 
-    plugin.clear_error();
+    let _ = plugin.clear_error();
     plugin.function_exists(name)
 }
 

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -183,26 +183,18 @@ fn test_cancel() {
     let mut plugin = Plugin::new(WASM_LOOP, [f], true).unwrap();
     let handle = plugin.cancel_handle();
 
-    let start = std::time::Instant::now();
-    let h = handle.clone();
-    std::thread::spawn(move || {
-        std::thread::sleep(std::time::Duration::from_secs(1));
-        assert!(h.cancel().is_ok());
-    });
-    let _output: Result<&[u8], Error> = plugin.call("loop_forever", "abc123");
-    let end = std::time::Instant::now();
-    let time = end - start;
-    println!("Cancelled plugin ran for {:?}", time);
-    let start = std::time::Instant::now();
-    let h = handle.clone();
-    std::thread::spawn(move || {
-        std::thread::sleep(std::time::Duration::from_secs(1));
-        assert!(h.cancel().is_ok());
-    });
-    let _output: Result<&[u8], Error> = plugin.call("loop_forever", "abc123");
-    let end = std::time::Instant::now();
-    let time = end - start;
-    println!("Cancelled plugin ran for {:?}", time);
+    for _ in 0..5 {
+        let start = std::time::Instant::now();
+        let h = handle.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            assert!(h.cancel().is_ok());
+        });
+        let _output: Result<&[u8], Error> = plugin.call("loop_forever", "abc123");
+        let end = std::time::Instant::now();
+        let time = end - start;
+        println!("Cancelled plugin ran for {:?}", time);
+    }
 }
 
 #[test]

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -184,15 +184,25 @@ fn test_cancel() {
     let handle = plugin.cancel_handle();
 
     let start = std::time::Instant::now();
+    let h = handle.clone();
     std::thread::spawn(move || {
         std::thread::sleep(std::time::Duration::from_secs(1));
-        assert!(handle.cancel().is_ok());
+        assert!(h.cancel().is_ok());
     });
     let _output: Result<&[u8], Error> = plugin.call("loop_forever", "abc123");
     let end = std::time::Instant::now();
     let time = end - start;
     println!("Cancelled plugin ran for {:?}", time);
-    // std::io::stdout().write_all(output).unwrap();
+    let start = std::time::Instant::now();
+    let h = handle.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        assert!(h.cancel().is_ok());
+    });
+    let _output: Result<&[u8], Error> = plugin.call("loop_forever", "abc123");
+    let end = std::time::Instant::now();
+    let time = end - start;
+    println!("Cancelled plugin ran for {:?}", time);
 }
 
 #[test]


### PR DESCRIPTION
We were updating the epoch deadline callback after the call has ended to ignore any timeouts that might happen when reading output, which would allow for the plugin to be cancelled successfully the first time a plugin is called but would fail after the first call. This PR fixes cancellation by resetting the epoch deadline and callback before each plugin call.

I tested this against the dotnet sdk tests, where this was discovered, and added a similar test to the runtime test suite,

Fixes #556 