### PR TITLE
cleanup: add PTR as an alias for ValType::I64

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -174,14 +174,14 @@ fn main() {
         .with_wasi(true)
         .with_function(
             "kv_read",
-            [ValType::I64],
-            [ValType::I64],
+            [PTR],
+            [PTR],
             kv_store.clone(),
             kv_read,
         )
         .with_function(
             "kv_write",
-            [ValType::I64, ValType::I64],
+            [PTR, PTR],
             [],
             kv_store.clone(),
             kv_write,

--- a/runtime/src/function.rs
+++ b/runtime/src/function.rs
@@ -25,6 +25,9 @@ pub enum ValType {
     ExternRef,
 }
 
+/// A wrapper around `ValType::I64` to specify arguments that are pointers to memory blocks
+pub const PTR: ValType = ValType::I64;
+
 impl From<wasmtime::ValType> for ValType {
     fn from(value: wasmtime::ValType) -> Self {
         use wasmtime::ValType::*;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -21,7 +21,7 @@ pub mod sdk;
 pub use current_plugin::CurrentPlugin;
 pub use extism_convert::{FromBytes, FromBytesOwned, ToBytes};
 pub use extism_manifest::{Manifest, Wasm};
-pub use function::{Function, UserData, Val, ValType};
+pub use function::{Function, UserData, Val, ValType, PTR};
 pub use plugin::{CancelHandle, Plugin, EXTISM_ENV_MODULE, EXTISM_USER_MODULE};
 pub use plugin_builder::PluginBuilder;
 


### PR DESCRIPTION
This will help simplify writing the types for host functions, `PTR` can be used for any arguments that will point to Extism memory instead of `ValType::I64`