### PR TITLE
refactor!: allow `Plugin::new` to take raw wasm or `Manifest`

### DIFF
--- a/manifest/Cargo.toml
+++ b/manifest/Cargo.toml
@@ -12,12 +12,10 @@ description = "Extism plug-in manifest crate"
 serde = {version = "1", features = ["derive"]}
 base64 = "0.21.0"
 schemars = {version = "0.8", optional=true}
+serde_json = "1"
 
 [features]
 json_schema = ["schemars"]
-
-[dev-dependencies]
-serde_json = "1"
 
 [[example]]
 name = "json_schema"

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -340,3 +340,17 @@ mod base64 {
             .map_err(serde::de::Error::custom)
     }
 }
+
+impl<'a> From<Manifest> for std::borrow::Cow<'a, [u8]> {
+    fn from(m: Manifest) -> Self {
+        let s = serde_json::to_vec(&m).unwrap();
+        std::borrow::Cow::Owned(s)
+    }
+}
+
+impl<'a> From<&Manifest> for std::borrow::Cow<'a, [u8]> {
+    fn from(m: &Manifest) -> Self {
+        let s = serde_json::to_vec(&m).unwrap();
+        std::borrow::Cow::Owned(s)
+    }
+}

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -43,7 +43,7 @@ fn main() {
     "https://github.com/extism/plugins/releases/latest/download/count_vowels.wasm"
   );
   let manifest = Manifest::new([url]);
-  let mut plugin = Plugin::new_with_manifest(&manifest, [], true).unwrap();
+  let mut plugin = Plugin::new(&manifest, [], true).unwrap();
   let res = plugin.call::<&str, &str>::("count_vowels", "Hello, world!").unwrap();
   println!("{}", res);
 }
@@ -105,11 +105,11 @@ Plug-ins may optionally take a configuration object. This is a static way to con
 
 ```rust
 let manifest = Manifest::new([url]);
-let mut plugin = Plugin::new_with_manifest(&manifest, [], true);
+let mut plugin = Plugin::new(&manifest, [], true);
 let res = plugin.call::<&str, &str>::("count_vowels", "Yellow, world!").unwrap();
 println!("{}", res);
 # => {"count": 3, "total": 3, "vowels": "aeiouAEIOU"}
-let mut plugin = Plugin::new_with_manifest(&manifest, [], true).with_config_key("vowels", "aeiouyAEIOUY");
+let mut plugin = Plugin::new(&manifest, [], true).with_config_key("vowels", "aeiouyAEIOUY");
 let res = plugin.call::<&str, &str>::("count_vowels", "Yellow, world!").unwrap();
 println!("{}", res);
 # => {"count": 4, "total": 4, "vowels": "aeiouyAEIOUY"}

--- a/runtime/benches/bench.rs
+++ b/runtime/benches/bench.rs
@@ -25,7 +25,7 @@ pub fn create_plugin(c: &mut Criterion) {
     g.significance_level(0.2);
     g.bench_function("create_plugin", |b| {
         b.iter(|| {
-            let _plugin = PluginBuilder::new_with_module(COUNT_VOWELS)
+            let _plugin = PluginBuilder::new(COUNT_VOWELS)
                 .with_wasi(true)
                 .build()
                 .unwrap();
@@ -40,7 +40,7 @@ struct Count {
 pub fn count_vowels(c: &mut Criterion) {
     let mut g = c.benchmark_group("count_vowels");
     g.sample_size(500);
-    let mut plugin = PluginBuilder::new_with_module(COUNT_VOWELS)
+    let mut plugin = PluginBuilder::new(COUNT_VOWELS)
         .with_wasi(true)
         .build()
         .unwrap();
@@ -63,12 +63,12 @@ pub fn reflect_1(c: &mut Criterion) {
     g.sample_size(500);
     g.noise_threshold(1.0);
     g.significance_level(0.2);
-    let mut plugin = PluginBuilder::new_with_module(REFLECT)
+    let mut plugin = PluginBuilder::new(REFLECT)
         .with_wasi(true)
         .with_function(
             "host_reflect",
-            [ValType::I64],
-            [ValType::I64],
+            [PTR],
+            [PTR],
             UserData::default(),
             hello_world,
         )
@@ -87,12 +87,12 @@ pub fn reflect_10(c: &mut Criterion) {
     g.sample_size(200);
     g.noise_threshold(1.0);
     g.significance_level(0.2);
-    let mut plugin = PluginBuilder::new_with_module(REFLECT)
+    let mut plugin = PluginBuilder::new(REFLECT)
         .with_wasi(true)
         .with_function(
             "host_reflect",
-            [ValType::I64],
-            [ValType::I64],
+            [PTR],
+            [PTR],
             UserData::default(),
             hello_world,
         )
@@ -111,12 +111,12 @@ pub fn reflect_100(c: &mut Criterion) {
     g.sample_size(50);
     g.noise_threshold(1.0);
     g.significance_level(0.2);
-    let mut plugin = PluginBuilder::new_with_module(REFLECT)
+    let mut plugin = PluginBuilder::new(REFLECT)
         .with_wasi(true)
         .with_function(
             "host_reflect",
-            [ValType::I64],
-            [ValType::I64],
+            [PTR],
+            [PTR],
             UserData::default(),
             hello_world,
         )

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -210,7 +210,7 @@ fn test_timeout() {
 
     let manifest = Manifest::new([extism_manifest::Wasm::data(WASM_LOOP)])
         .with_timeout(std::time::Duration::from_secs(1));
-    let mut plugin = Plugin::new_with_manifest(&manifest, [f], true).unwrap();
+    let mut plugin = Plugin::new(&manifest, [f], true).unwrap();
 
     let start = std::time::Instant::now();
     let output: Result<&[u8], Error> = plugin.call("loop_forever", "abc123");
@@ -317,7 +317,7 @@ fn test_memory_max() {
     // Should fail with memory.max set
     let manifest =
         Manifest::new([extism_manifest::Wasm::data(WASM_NO_FUNCTIONS)]).with_memory_max(16);
-    let mut plugin = Plugin::new_with_manifest(&manifest, [], true).unwrap();
+    let mut plugin = Plugin::new(&manifest, [], true).unwrap();
     let output: Result<String, Error> = plugin.call("count_vowels", "a".repeat(65536 * 2));
     assert!(output.is_err());
 
@@ -328,13 +328,13 @@ fn test_memory_max() {
     // Should pass with memory.max set to a large enough number
     let manifest =
         Manifest::new([extism_manifest::Wasm::data(WASM_NO_FUNCTIONS)]).with_memory_max(17);
-    let mut plugin = Plugin::new_with_manifest(&manifest, [], true).unwrap();
+    let mut plugin = Plugin::new(&manifest, [], true).unwrap();
     let output: Result<String, Error> = plugin.call("count_vowels", "a".repeat(65536 * 2));
     assert!(output.is_ok());
 
     // Should pass without it
     let manifest = Manifest::new([extism_manifest::Wasm::data(WASM_NO_FUNCTIONS)]);
-    let mut plugin = Plugin::new_with_manifest(&manifest, [], true).unwrap();
+    let mut plugin = Plugin::new(&manifest, [], true).unwrap();
     let output: Result<String, Error> = plugin.call("count_vowels", "a".repeat(65536 * 2));
     assert!(output.is_ok());
 }
@@ -370,7 +370,7 @@ fn test_extism_error() {
         UserData::default(),
         hello_world_set_error,
     );
-    let mut plugin = Plugin::new_with_manifest(&manifest, [f], true).unwrap();
+    let mut plugin = Plugin::new(&manifest, [f], true).unwrap();
     let output: Result<String, Error> = plugin.call("count_vowels", "a".repeat(1024));
     assert!(output.is_err());
     assert_eq!(output.unwrap_err().root_cause().to_string(), "TEST");

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -43,16 +43,16 @@ fn it_works() {
     assert!(set_log_file("test.log", log::Level::Trace).is_ok());
     let f = Function::new(
         "hello_world",
-        [ValType::I64],
-        [ValType::I64],
+        [PTR],
+        [PTR],
         UserData::default(),
         hello_world,
     )
     .with_namespace(EXTISM_USER_MODULE);
     let g = Function::new(
         "hello_world",
-        [ValType::I64],
-        [ValType::I64],
+        [PTR],
+        [PTR],
         UserData::default(),
         hello_world_panic,
     )
@@ -142,8 +142,8 @@ fn test_plugin_threads() {
         PluginBuilder::new_with_module(WASM)
             .with_function(
                 "hello_world",
-                [ValType::I64],
-                [ValType::I64],
+                [PTR],
+                [PTR],
                 UserData::default(),
                 hello_world,
             )
@@ -175,8 +175,8 @@ fn test_plugin_threads() {
 fn test_cancel() {
     let f = Function::new(
         "hello_world",
-        [ValType::I64],
-        [ValType::I64],
+        [PTR],
+        [PTR],
         UserData::default(),
         hello_world,
     );
@@ -202,8 +202,8 @@ fn test_cancel() {
 fn test_timeout() {
     let f = Function::new(
         "hello_world",
-        [ValType::I64],
-        [ValType::I64],
+        [PTR],
+        [PTR],
         UserData::default(),
         hello_world,
     );
@@ -236,8 +236,8 @@ typed_plugin!(CountVowelsPlugin {
 fn test_typed_plugin_macro() {
     let f = Function::new(
         "hello_world",
-        [ValType::I64],
-        [ValType::I64],
+        [PTR],
+        [PTR],
         UserData::default(),
         hello_world,
     );
@@ -254,8 +254,8 @@ fn test_typed_plugin_macro() {
 fn test_multiple_instantiations() {
     let f = Function::new(
         "hello_world",
-        [ValType::I64],
-        [ValType::I64],
+        [PTR],
+        [PTR],
         UserData::default(),
         hello_world,
     );
@@ -296,8 +296,8 @@ fn test_fuzz_reflect_plugin() {
     // assert!(set_log_file("stdout", Some(log::Level::Trace)));
     let f = Function::new(
         "host_reflect",
-        [ValType::I64],
-        [ValType::I64],
+        [PTR],
+        [PTR],
         UserData::default(),
         hello_world,
     );
@@ -365,8 +365,8 @@ fn test_extism_error() {
     let manifest = Manifest::new([extism_manifest::Wasm::data(WASM)]);
     let f = Function::new(
         "hello_world",
-        [ValType::I64],
-        [ValType::I64],
+        [PTR],
+        [PTR],
         UserData::default(),
         hello_world_set_error,
     );
@@ -377,12 +377,12 @@ fn test_extism_error() {
 
     let f = Function::new(
         "hello_world",
-        [ValType::I64],
-        [ValType::I64],
+        [PTR],
+        [PTR],
         UserData::default(),
         hello_world_set_error_bail,
     );
-    let mut plugin = Plugin::new_with_manifest(&manifest, [f], true).unwrap();
+    let mut plugin = Plugin::new(&manifest, [f], true).unwrap();
     let output: Result<String, Error> = plugin.call("count_vowels", "a".repeat(1024));
     assert!(output.is_err());
     println!("{:?}", output);
@@ -393,8 +393,8 @@ fn test_extism_error() {
 fn test_extism_memdump() {
     let f = Function::new(
         "hello_world",
-        [ValType::I64],
-        [ValType::I64],
+        [PTR],
+        [PTR],
         UserData::default(),
         hello_world_set_error,
     );
@@ -414,8 +414,8 @@ fn test_extism_memdump() {
 fn test_extism_coredump() {
     let f = Function::new(
         "hello_world",
-        [ValType::I64],
-        [ValType::I64],
+        [PTR],
+        [PTR],
         UserData::default(),
         hello_world_set_error,
     );
@@ -457,8 +457,8 @@ fn test_userdata() {
         let file = std::fs::File::create(&path).unwrap();
         let f = Function::new(
             "hello_world",
-            [ValType::I64],
-            [ValType::I64],
+            [PTR],
+            [PTR],
             UserData::new(file),
             hello_world_user_data,
         );

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -139,7 +139,7 @@ fn it_works() {
 #[test]
 fn test_plugin_threads() {
     let p = std::sync::Arc::new(std::sync::Mutex::new(
-        PluginBuilder::new_with_module(WASM)
+        PluginBuilder::new(WASM)
             .with_function(
                 "hello_world",
                 [PTR],
@@ -398,7 +398,7 @@ fn test_extism_memdump() {
         UserData::default(),
         hello_world_set_error,
     );
-    let mut plugin = PluginBuilder::new_with_module(WASM)
+    let mut plugin = PluginBuilder::new(WASM)
         .with_wasi(true)
         .with_functions([f])
         .with_memdump("extism.mem")
@@ -462,7 +462,7 @@ fn test_userdata() {
             UserData::new(file),
             hello_world_user_data,
         );
-        let mut plugin = PluginBuilder::new_with_module(WASM)
+        let mut plugin = PluginBuilder::new(WASM)
             .with_wasi(true)
             .with_functions([f])
             .build()


### PR DESCRIPTION
- Removes `Plugin::new_with_manifest` and updates `Plugin::new` to take wasm bytes or `Manifest` using the new `WasmInput` trait
- Removes `PluginBuilder::new_with_module` in favor of a `PluginBuilder::new` with a `WasmInput` argument