### PR TITLE
cleanup: simplify logging, include plugin ID in log messages

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1"
 toml = "0.8"
 sha2 = "0.10"
 log = "0.4"
-log4rs = "1.1"
+fern = "0.6.2"
 url = "2"
 glob = "0.3"
 ureq = {version = "2.5", optional=true}
@@ -25,6 +25,7 @@ extism-manifest = { version = "1.0.0-alpha.0", path = "../manifest" }
 extism-convert = { version = "0.2", path = "../convert" }
 uuid = { version = "1", features = ["v4"] }
 libc = "0.2"
+humantime = "2.1.0"
 
 [features]
 default = ["http", "register-http", "register-filesystem"]

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -11,7 +11,7 @@ fn main() {
 /** An alias for I64 to signify an Extism pointer */
 #define PTR I64
 ";
-    if let Ok(bindings) = cbindgen::Builder::new()
+    match cbindgen::Builder::new()
         .with_crate(".")
         .with_language(cbindgen::Language::C)
         .with_no_includes()
@@ -29,6 +29,11 @@ fn main() {
         .with_style(cbindgen::Style::Type)
         .generate()
     {
-        bindings.write_to_file("extism.h");
+        Ok(bindings) => {
+            bindings.write_to_file("extism.h");
+        }
+        Err(e) => {
+            panic!("Error building header: {e}")
+        }
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -20,7 +20,7 @@ pub mod sdk;
 
 pub use current_plugin::CurrentPlugin;
 pub use extism_convert::{FromBytes, FromBytesOwned, ToBytes};
-pub use extism_manifest::{Manifest, Wasm};
+pub use extism_manifest::{Manifest, Wasm, WasmMetadata};
 pub use function::{Function, UserData, Val, ValType, PTR};
 pub use plugin::{CancelHandle, Plugin, EXTISM_ENV_MODULE, EXTISM_USER_MODULE};
 pub use plugin_builder::PluginBuilder;

--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -269,6 +269,7 @@ pub fn log(
     _output: &mut [Val],
 ) -> Result<(), Error> {
     let data: &mut CurrentPlugin = caller.data_mut();
+    let target = format!("extism::plugin::{}", data.id);
     let offset = args!(input, 0, i64) as u64;
 
     let handle = match data.memory_handle(offset) {
@@ -279,8 +280,8 @@ pub fn log(
     let buf = data.memory_str(handle);
 
     match buf {
-        Ok(buf) => log::log!(level, "{}", buf),
-        Err(_) => log::log!(level, "{:?}", buf),
+        Ok(buf) => log::log!(target: target.as_str(), level, "{}", buf),
+        Err(_) => log::log!(target: target.as_str(), level, "{:?}", buf),
     }
     Ok(())
 }

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -134,6 +134,9 @@ fn it_works() {
     let avg: std::time::Duration = sum / num_tests as u32;
 
     println!("wasm function call (avg, N = {}): {:?}", num_tests, avg);
+
+    let meta = std::fs::metadata("test.log").unwrap();
+    assert!(meta.len() > 0);
 }
 
 #[test]


### PR DESCRIPTION
My initial goal was to make logging configurable for each plugin instead of global but wasn't able to accomplish that in this PR (still looking into it)

- Switches from `log4rs` to `fern` - this significantly simplifies the logging code 
  - Also considered `simplelog`
- Adds `plugin.id` to the logs whenever available
- Uses `extism::plugin::$id` target for functions logged from the PDK