### PR TITLE
feat: add add_subdirectory compatible cmake config

### DIFF
--- a/libextism/CMakeLists.txt
+++ b/libextism/CMakeLists.txt
@@ -1,0 +1,15 @@
+project(extism)
+cmake_minimum_required(VERSION 3.22)
+include(FetchContent)
+
+FetchContent_Declare(
+    Corrosion
+    GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
+    GIT_TAG v0.4.4
+)
+FetchContent_MakeAvailable(Corrosion)
+
+corrosion_import_crate(MANIFEST_PATH ./Cargo.toml PROFILE release CRATES libextism FEATURES default)
+target_include_directories(extism INTERFACE ../runtime)
+target_include_directories(extism-static INTERFACE ../runtime)
+target_include_directories(extism-shared INTERFACE ../runtime)


### PR DESCRIPTION
This enables cmake in-tree builds with libextism such as with the cpp-sdk: https://github.com/extism/cpp-sdk/pull/7