### PR TITLE
chore: loosen dependency requirements for base64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,4 @@
 [workspace]
 resolver = "2"
-members = [
-  "extism-maturin",
-  "manifest",
-  "runtime",
-  "libextism",
-  "convert"
-]
+members = ["extism-maturin", "manifest", "runtime", "libextism", "convert"]
 exclude = ["kernel"]

--- a/convert/Cargo.toml
+++ b/convert/Cargo.toml
@@ -11,14 +11,14 @@ description = "Traits to make Rust types usable with Extism"
 
 [dependencies]
 anyhow = "1.0.75"
-base64 = "0.21.3"
+base64 = "~0.21"
 prost = { version = "0.12.0", optional = true }
 rmp-serde = { version = "1.1.2", optional = true }
 serde = "1.0.186"
 serde_json = "1.0.105"
 
 [dev-dependencies]
-serde = {version = "1.0.186", features = ["derive"]}
+serde = { version = "1.0.186", features = ["derive"] }
 
 [features]
 default = ["msgpack", "protobuf"]

--- a/manifest/Cargo.toml
+++ b/manifest/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/extism/extism"
 description = "Extism plug-in manifest crate"
 
 [dependencies]
-serde = {version = "1", features = ["derive"]}
-base64 = "0.21.0"
-schemars = {version = "0.8", optional=true}
+serde = { version = "1", features = ["derive"] }
+base64 = "~0.21"
+schemars = { version = "0.8", optional = true }
 serde_json = "1"
 
 [features]
@@ -20,4 +20,3 @@ json_schema = ["schemars"]
 [[example]]
 name = "json_schema"
 required-features = ["json_schema"]
-


### PR DESCRIPTION
Attempts to address an error seen when upgrading both Rust PDK & SDK to latest:

```
    Updating git repository `https://github.com/extism/extism.git`
    Updating git repository `https://github.com/extism/rust-pdk.git`
    Updating crates.io index
error: failed to select a version for `base64`.
    ... required by package `extism-convert v0.2.0 (https://github.com/extism/extism.git?branch=main#7636c873)`
    ... which satisfies git dependency `extism-convert` of package `extism v1.0.0-alpha.0 (https://github.com/extism/extism.git?branch=main#7636c873)`
    ... which satisfies git dependency `extism` of package `proto_core v0.22.4 (/Users/miles/Projects/proto/crates/core)`
    ... which satisfies path dependency `proto_core` (locked to 0.22.4) of package `proto_cli v0.22.0 (/Users/miles/Projects/proto/crates/cli)`
versions that meet the requirements `^0.21.3` are: 0.21.5, 0.21.4, 0.21.3

all possible versions conflict with previously selected packages.

  previously selected package `base64 v0.21.0`
    ... which satisfies dependency `base64 = "^0.21.0"` (locked to 0.21.0) of package `extism-manifest v0.5.0`
    ... which satisfies dependency `extism-manifest = "^0.5.0"` (locked to 0.5.0) of package `extism-pdk v1.0.0-beta.0 (https://github.com/extism/rust-pdk.git?branch=main#009bf808)`
    ... which satisfies git dependency `extism-pdk` of package `proto_pdk v0.10.2 (/Users/miles/Projects/proto/crates/pdk)`

failed to select a version for `base64` which could resolve this conflict
```