### PR TITLE
build: drive crate versions from workspace; drive workspace version from ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [ main, "v*" ]
     tags:
       - 'v*'
 
@@ -77,6 +77,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set version
+        shell: bash
+        run: |
+          version="${{ github.ref }}"
+          if [[ "$version" = "refs/heads/main" ]]; then
+            version="0.0.0-dev"
+          else
+            version="${version/refs\/tags\/v/}"
+          fi
+          sed -i -e "s/0.0.0+replaced-by-ci/${version}/g" Cargo.toml
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -97,19 +108,6 @@ jobs:
           use-cross: ${{ matrix.os != 'windows' }}
           command: build
           args: --release --target ${{ matrix.target }} -p ${{ env.RUNTIME_CRATE }}
-
-      - name: set extism-maturin version
-        shell: bash
-        run: |
-          pyproject="$(cat extism-maturin/pyproject.toml)"
-          version="${{ github.ref }}"
-          if [[ "$version" = "refs/heads/main" ]]; then
-            version="0.0.0-dev"
-          else
-            version="${version/refs\/tags\/v/}"
-          fi
-
-          <<<"$pyproject" >extism-maturin/pyproject.toml sed -e 's/^version = "0.0.0.replaced-by-ci"/version = "'"$version"'"/g'
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,8 @@ jobs:
             version="${version/refs\/tags\/v/}"
           fi
           sed -i -e "s/0.0.0+replaced-by-ci/${version}/g" Cargo.toml
+          pyproject="$(cat extism-maturin/pyproject.toml)"
+          <<<"$pyproject" >extism-maturin/pyproject.toml sed -e 's/^version = "0.0.0.replaced-by-ci"/version = "'"$version"'"/g'
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,16 @@
 resolver = "2"
 members = ["extism-maturin", "manifest", "runtime", "libextism", "convert"]
 exclude = ["kernel"]
+
+[workspace.package]
+edition = "2021"
+authors = ["The Extism Authors", "oss@extism.org"]
+license = "BSD-3-Clause"
+homepage = "https://extism.org"
+repository = "https://github.com/extism/extism"
+version = "0.0.0+replaced-by-ci"
+
+[workspace.dependencies]
+extism = { path = "./runtime", version = "0.0.0+replaced-by-ci" }
+extism-convert = { path = "./convert", version = "0.0.0+replaced-by-ci" }
+extism-manifest = { path = "./manifest", version = "0.0.0+replaced-by-ci" }

--- a/convert/Cargo.toml
+++ b/convert/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "extism-convert"
-version = "0.2.0"
-edition = "2021"
-authors = ["The Extism Authors", "oss@extism.org"]
-license = "BSD-3-Clause"
 readme = "./README.md"
-homepage = "https://extism.org"
-repository = "https://github.com/extism/extism"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+version.workspace = true
 description = "Traits to make Rust types usable with Extism"
 
 [dependencies]

--- a/extism-maturin/Cargo.toml
+++ b/extism-maturin/Cargo.toml
@@ -1,14 +1,18 @@
 [package]
 name = "extism-sys"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [lib]
 name = "extism_sys"
 crate-type = ["cdylib"]
 
 [dependencies]
-extism = {path = "../runtime"}
+extism = { workspace = true }
 
 [build-dependencies]
 cc = "1"

--- a/libextism/Cargo.toml
+++ b/libextism/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "libextism"
-version = "1.0.0-rc3"
-edition = "2021"
-authors = ["The Extism Authors", "oss@extism.org"]
-license = "BSD-3-Clause"
-homepage = "https://extism.org"
-repository = "https://github.com/extism/extism"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+version.workspace = true
 description = "libextism"
 
 [lib]
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "staticlib"]
 doc = false
 
 [dependencies]
-extism = {path = "../runtime"}
+extism = {workspace = true, path = "../runtime"}
 
 [features]
 default = ["http", "register-http", "register-filesystem"]

--- a/manifest/Cargo.toml
+++ b/manifest/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "extism-manifest"
-version = "1.0.0-rc3"
-edition = "2021"
-authors = ["The Extism Authors", "oss@extism.org"]
-license = "BSD-3-Clause"
-homepage = "https://extism.org"
-repository = "https://github.com/extism/extism"
 description = "Extism plug-in manifest crate"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "extism"
-version = "1.0.0-rc3"
-edition = "2021"
-authors = ["The Extism Authors", "oss@extism.org"]
-license = "BSD-3-Clause"
-homepage = "https://extism.org"
-repository = "https://github.com/extism/extism"
 description = "Extism runtime and Rust SDK"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 wasmtime = ">= 14.0.0, < 16.0.0"
@@ -21,8 +21,8 @@ tracing-subscriber = {version = "0.3", features = ["std", "env-filter", "fmt"]}
 url = "2"
 glob = "0.3"
 ureq = {version = "2.5", optional=true}
-extism-manifest = { version = "1.0.0-rc3", path = "../manifest" }
-extism-convert = { version = "0.2", path = "../convert" }
+extism-manifest = { workspace = true }
+extism-convert = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 libc = "0.2"
 


### PR DESCRIPTION
This is an attempt to sand down [a sharp edge](https://github.com/extism/extism/actions/runs/6949120346/job/18906546065#step:4:476) around releases – keeping the `Cargo.toml` versions in-sync with the release tag, & the versions of the workspace crates aligned with one another.