### PR TITLE
build: drive cargo releases from git tag

### DIFF
--- a/.github/workflows/release-convert.yaml
+++ b/.github/workflows/release-convert.yaml
@@ -1,4 +1,6 @@
 on:
+  release:
+    types: [published, edited]
   workflow_dispatch:
 
 name: Release extism-convert
@@ -10,6 +12,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: '${{ github.ref }}'
+
+      - name: Set version
+        shell: bash
+        run: |
+          version="${{ github.ref }}"
+          if [[ "$version" = "refs/heads/main" ]]; then
+            version="0.0.0-dev"
+          else
+            version="${version/refs\/tags\/v/}"
+          fi
+          sed -i -e "s/0.0.0+replaced-by-ci/${version}/g" Cargo.toml
+          pyproject="$(cat extism-maturin/pyproject.toml)"
+          <<<"$pyproject" >extism-maturin/pyproject.toml sed -e 's/^version = "0.0.0.replaced-by-ci"/version = "'"$version"'"/g'
 
       - name: Setup Rust env
         uses: actions-rs/toolchain@v1
@@ -23,4 +40,4 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_API_TOKEN }}
         run: |
-          cargo publish --manifest-path convert/Cargo.toml
+          cargo publish --manifest-path convert/Cargo.toml --allow-dirty

--- a/.github/workflows/release-manifest.yaml
+++ b/.github/workflows/release-manifest.yaml
@@ -1,4 +1,6 @@
 on:
+  release:
+    types: [published, edited]
   workflow_dispatch:
 
 name: Release extism-manifest
@@ -10,6 +12,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: '${{ github.ref }}'
+
+      - name: Set version
+        shell: bash
+        run: |
+          version="${{ github.ref }}"
+          if [[ "$version" = "refs/heads/main" ]]; then
+            version="0.0.0-dev"
+          else
+            version="${version/refs\/tags\/v/}"
+          fi
+          sed -i -e "s/0.0.0+replaced-by-ci/${version}/g" Cargo.toml
+          pyproject="$(cat extism-maturin/pyproject.toml)"
+          <<<"$pyproject" >extism-maturin/pyproject.toml sed -e 's/^version = "0.0.0.replaced-by-ci"/version = "'"$version"'"/g'
 
       - name: Setup Rust env
         uses: actions-rs/toolchain@v1
@@ -23,4 +40,4 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_API_TOKEN }}
         run: |
-          cargo publish --manifest-path manifest/Cargo.toml
+          cargo publish --manifest-path manifest/Cargo.toml --allow-dirty

--- a/.github/workflows/release-rust.yaml
+++ b/.github/workflows/release-rust.yaml
@@ -1,4 +1,6 @@
 on:
+  release:
+    types: [published, edited]
   workflow_dispatch:
 
 name: Release Runtime/Rust SDK
@@ -10,6 +12,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: '${{ github.ref }}'
+
+      - name: Set version
+        shell: bash
+        run: |
+          version="${{ github.ref }}"
+          if [[ "$version" = "refs/heads/main" ]]; then
+            version="0.0.0-dev"
+          else
+            version="${version/refs\/tags\/v/}"
+          fi
+          sed -i -e "s/0.0.0+replaced-by-ci/${version}/g" Cargo.toml
+          pyproject="$(cat extism-maturin/pyproject.toml)"
+          <<<"$pyproject" >extism-maturin/pyproject.toml sed -e 's/^version = "0.0.0.replaced-by-ci"/version = "'"$version"'"/g'
 
       - name: Setup Rust env
         uses: actions-rs/toolchain@v1
@@ -23,4 +40,4 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_API_TOKEN }}
         run: |
-          cargo publish --manifest-path runtime/Cargo.toml
+          cargo publish --manifest-path runtime/Cargo.toml --allow-dirty

--- a/extism-maturin/Cargo.toml
+++ b/extism-maturin/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "extism-sys"
 edition.workspace = true
-authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 version.workspace = true
+# Explicitly omit authors from this package since our Cargo "authors" are
+# incompatible with PyPI's requirements.
+# authors.workspace = true
 
 [lib]
 name = "extism_sys"


### PR DESCRIPTION
Follow-up to f7d297f98f4b75bdce969afd946c459916402b8f.

Update the release workflows for the dependent crates. The Cargo workflows run on GitHub release publish to match the Python package release workflow. This means all of our crates are versioned in lockstep by the Git tag.

There are four changes:

1. Trigger the workflows on GitHub release publish
2. Add the `set version` step from `release.yml` to modify the version tags in `Cargo.toml`.
3. Publish with `--allow-dirty` (to account for the edit in step 2)
4. In `extism-maturin`, do not inherit `authors` from the workspace since [PyPI rejects the value we have set](https://github.com/extism/extism/actions/runs/7012534645/job/19077216730#step:7:23).