### PR TITLE
cleanup: simplify main module resolution

### DIFF
--- a/runtime/src/manifest.rs
+++ b/runtime/src/manifest.rs
@@ -75,7 +75,6 @@ fn to_module(engine: &Engine, wasm: &extism_manifest::Wasm) -> Result<(String, M
             meta,
         } => {
             // Get the file name
-            let file_name = url.split('/').last().unwrap_or_default();
             let name = match &meta.name {
                 Some(name) => name.as_str(),
                 None => meta.name.as_deref().unwrap_or(MAIN_KEY),
@@ -178,8 +177,12 @@ pub(crate) fn modules(
         return Ok(());
     }
 
-    for f in &manifest.wasm {
-        let (name, m) = to_module(engine, f)?;
+    for (i, f) in manifest.wasm.iter().enumerate() {
+        let (mut name, m) = to_module(engine, f)?;
+        // Rename the last module to `main` if no main is defined already
+        if i == manifest.wasm.len() - 1 && !modules.contains_key(MAIN_KEY) {
+            name = MAIN_KEY.to_string();
+        }
         if modules.contains_key(&name) {
             anyhow::bail!("Duplicate module name found in Extism manifest: {name}");
         }

--- a/runtime/src/manifest.rs
+++ b/runtime/src/manifest.rs
@@ -166,7 +166,9 @@ pub(crate) fn modules(
     modules: &mut BTreeMap<String, Module>,
 ) -> Result<(), Error> {
     if manifest.wasm.is_empty() {
-        return Err(anyhow::format_err!("No wasm files specified"));
+        return Err(anyhow::format_err!(
+            "No wasm files specified in Extism manifest"
+        ));
     }
 
     // If there's only one module, it should be called `main`
@@ -178,6 +180,9 @@ pub(crate) fn modules(
 
     for f in &manifest.wasm {
         let (name, m) = to_module(engine, f)?;
+        if modules.contains_key(&name) {
+            anyhow::bail!("Duplicate module name found in Extism manifest: {name}");
+        }
         trace!("Found module {}", name);
         modules.insert(name, m);
     }

--- a/runtime/src/manifest.rs
+++ b/runtime/src/manifest.rs
@@ -45,10 +45,7 @@ fn to_module(engine: &Engine, wasm: &extism_manifest::Wasm) -> Result<(String, M
 
             // Figure out a good name for the file
             let name = match &meta.name {
-                None => {
-                    let name = path.with_extension("");
-                    name.file_name().unwrap().to_string_lossy().to_string()
-                }
+                None => meta.name.as_deref().unwrap_or("main").to_string(),
                 Some(n) => n.clone(),
             };
 
@@ -81,17 +78,7 @@ fn to_module(engine: &Engine, wasm: &extism_manifest::Wasm) -> Result<(String, M
             let file_name = url.split('/').last().unwrap_or_default();
             let name = match &meta.name {
                 Some(name) => name.as_str(),
-                None => {
-                    let mut name = "main";
-                    if let Some(n) = file_name.strip_suffix(".wasm") {
-                        name = n;
-                    }
-
-                    if let Some(n) = file_name.strip_suffix(".wat") {
-                        name = n;
-                    }
-                    name
-                }
+                None => meta.name.as_deref().unwrap_or("main"),
             };
 
             #[cfg(not(feature = "register-http"))]

--- a/runtime/src/manifest.rs
+++ b/runtime/src/manifest.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 
 use sha2::Digest;
 
-use crate::plugin::WasmInput;
+use crate::plugin::{WasmInput, MAIN_KEY};
 use crate::*;
 
 fn hex(data: &[u8]) -> String {
@@ -45,7 +45,7 @@ fn to_module(engine: &Engine, wasm: &extism_manifest::Wasm) -> Result<(String, M
 
             // Figure out a good name for the file
             let name = match &meta.name {
-                None => meta.name.as_deref().unwrap_or("main").to_string(),
+                None => meta.name.as_deref().unwrap_or(MAIN_KEY).to_string(),
                 Some(n) => n.clone(),
             };
 
@@ -60,7 +60,7 @@ fn to_module(engine: &Engine, wasm: &extism_manifest::Wasm) -> Result<(String, M
         extism_manifest::Wasm::Data { meta, data } => {
             check_hash(&meta.hash, data)?;
             Ok((
-                meta.name.as_deref().unwrap_or("main").to_string(),
+                meta.name.as_deref().unwrap_or(MAIN_KEY).to_string(),
                 Module::new(engine, data)?,
             ))
         }
@@ -78,7 +78,7 @@ fn to_module(engine: &Engine, wasm: &extism_manifest::Wasm) -> Result<(String, M
             let file_name = url.split('/').last().unwrap_or_default();
             let name = match &meta.name {
                 Some(name) => name.as_str(),
-                None => meta.name.as_deref().unwrap_or("main"),
+                None => meta.name.as_deref().unwrap_or(MAIN_KEY),
             };
 
             #[cfg(not(feature = "register-http"))]
@@ -144,7 +144,7 @@ pub(crate) fn load(
             }
 
             let m = Module::new(engine, data)?;
-            mods.insert("main".to_string(), m);
+            mods.insert(MAIN_KEY.to_string(), m);
             Ok((Default::default(), mods))
         }
         WasmInput::Manifest(m) => {
@@ -172,7 +172,7 @@ pub(crate) fn modules(
     // If there's only one module, it should be called `main`
     if manifest.wasm.len() == 1 {
         let (_, m) = to_module(engine, &manifest.wasm[0])?;
-        modules.insert("main".to_string(), m);
+        modules.insert(MAIN_KEY.to_string(), m);
         return Ok(());
     }
 

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -4,6 +4,7 @@ use crate::*;
 
 pub const EXTISM_ENV_MODULE: &str = "extism:host/env";
 pub const EXTISM_USER_MODULE: &str = "extism:host/user";
+pub(crate) const MAIN_KEY: &str = "main";
 
 #[derive(Default, Clone)]
 pub(crate) struct Output {
@@ -248,11 +249,11 @@ impl Plugin {
 
         // Get the `main` module, or the last one if `main` doesn't exist
         let main = modules
-            .get("main")
+            .get(MAIN_KEY)
             .unwrap_or_else(|| modules.values().last().unwrap());
 
         for (name, module) in modules.iter() {
-            if name != "main" {
+            if name != MAIN_KEY {
                 linker.module(&mut store, name, module)?;
             }
         }
@@ -350,11 +351,11 @@ impl Plugin {
 
             let main = self
                 .modules
-                .get("main")
+                .get(MAIN_KEY)
                 .unwrap_or_else(|| self.modules.values().last().unwrap());
 
             for (name, module) in self.modules.iter() {
-                if name != "main" {
+                if name != MAIN_KEY {
                     self.linker.module(&mut self.store, name, module)?;
                 }
             }
@@ -406,7 +407,7 @@ impl Plugin {
 
     /// Returns `true` if the given function exists, otherwise `false`
     pub fn function_exists(&mut self, function: impl AsRef<str>) -> bool {
-        self.modules["main"]
+        self.modules[MAIN_KEY]
             .get_export(function.as_ref())
             .map(|x| x.func().is_some())
             .unwrap_or(false)

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -225,6 +225,8 @@ impl Plugin {
         let (manifest, modules) = manifest::load(&engine, wasm)?;
         if modules.len() <= 1 {
             anyhow::bail!("No wasm modules provided");
+        } else if !modules.contains_key(MAIN_KEY) {
+            anyhow::bail!("No main module provided");
         }
 
         let available_pages = manifest.memory.max_pages;
@@ -247,11 +249,7 @@ impl Plugin {
             })?;
         }
 
-        // Get the `main` module, or the last one if `main` doesn't exist
-        let main = modules
-            .get(MAIN_KEY)
-            .unwrap_or_else(|| modules.values().last().unwrap());
-
+        let main = &modules[MAIN_KEY];
         for (name, module) in modules.iter() {
             if name != MAIN_KEY {
                 linker.module(&mut store, name, module)?;
@@ -349,11 +347,7 @@ impl Plugin {
                     .limiter(|internal| internal.memory_limiter.as_mut().unwrap());
             }
 
-            let main = self
-                .modules
-                .get(MAIN_KEY)
-                .unwrap_or_else(|| self.modules.values().last().unwrap());
-
+            let main = &self.modules[MAIN_KEY];
             for (name, module) in self.modules.iter() {
                 if name != MAIN_KEY {
                     self.linker.module(&mut self.store, name, module)?;


### PR DESCRIPTION
This PR simplifies the resolution of the `main` module when multiple modules are provided. Before we would try to look at the path/URL when the wasm was coming from disk or via HTTP, now any module missing a name will be used as `main`. This is much nicer and more consistent since this is what was being done when no filename was available (i.e. raw data modules). It also make sense because non-main modules will need to be named for the functions to be linked correctly.