### PR TITLE
refactor!: better scoping of arguments in host_fn macro, allow visibility in macros to be specified 

### DIFF
--- a/convert/src/encoding.rs
+++ b/convert/src/encoding.rs
@@ -15,10 +15,10 @@ use base64::Engine;
 /// and `FromBytesOwned` using `serde_json::from_vec`
 #[macro_export]
 macro_rules! encoding {
-    ($name:ident, $to_vec:expr, $from_slice:expr) => {
+    ($pub:vis $name:ident, $to_vec:expr, $from_slice:expr) => {
         #[doc = concat!(stringify!($name), " encoding")]
         #[derive(Debug)]
-        pub struct $name<T>(pub T);
+        $pub struct $name<T>(pub T);
 
         impl<T> $name<T> {
             pub fn into_inner(self) -> T {
@@ -50,10 +50,10 @@ macro_rules! encoding {
     };
 }
 
-encoding!(Json, serde_json::to_vec, serde_json::from_slice);
+encoding!(pub Json, serde_json::to_vec, serde_json::from_slice);
 
 #[cfg(feature = "msgpack")]
-encoding!(Msgpack, rmp_serde::to_vec, rmp_serde::from_slice);
+encoding!(pub Msgpack, rmp_serde::to_vec, rmp_serde::from_slice);
 
 impl<'a> ToBytes<'a> for serde_json::Value {
     type Bytes = Vec<u8>;

--- a/runtime/src/function.rs
+++ b/runtime/src/function.rs
@@ -259,11 +259,11 @@ impl Function {
 //     definition.
 #[macro_export]
 macro_rules! host_fn {
-    ($name: ident  ($($arg:ident : $argty:ty),*) $(-> $ret:ty)? $b:block) => {
-        $crate::host_fn!($name (user_data: (); $($arg : $argty),*) $(-> $ret)? {$b});
+    ($pub:vis $name: ident  ($($arg:ident : $argty:ty),*) $(-> $ret:ty)? $b:block) => {
+       $crate::host_fn!($pub $name (user_data: (); $($arg : $argty),*) $(-> $ret)? {$b});
     };
-    ($name: ident  ($user_data:ident : $dataty:ty; $($arg:ident : $argty:ty),*) $(-> $ret:ty)? $b:block) => {
-        fn $name(
+    ($pub:vis $name: ident  ($user_data:ident : $dataty:ty; $($arg:ident : $argty:ty),*) $(-> $ret:ty)? $b:block) => {
+        $pub fn $name(
             plugin: &mut $crate::CurrentPlugin,
             inputs: &[$crate::Val],
             outputs: &mut [$crate::Val],

--- a/runtime/src/function.rs
+++ b/runtime/src/function.rs
@@ -270,16 +270,19 @@ macro_rules! host_fn {
             #[allow(unused)]
             mut $user_data: $crate::UserData<$dataty>,
         ) -> Result<(), $crate::Error> {
-            let mut index = 0;
-            $(
-                let $arg: $argty = plugin.memory_get_val(&inputs[index])?;
-                #[allow(unused_assignments)]
-                {
-                    index += 1;
-                }
-            )*
-            let output = move || -> Result<_, $crate::Error> { $b };
-            let output: $crate::convert::MemoryHandle = plugin.memory_new(&output()?)?;
+            let output = {
+                let mut index = 0;
+                $(
+                    let $arg: $argty = plugin.memory_get_val(&inputs[index])?;
+                    #[allow(unused_assignments)]
+                    {
+                        index += 1;
+                    }
+                )*
+                move || -> Result<_, $crate::Error> { $b }
+            };
+            let output = output()?;
+            let output: $crate::convert::MemoryHandle = plugin.memory_new(&output)?;
             if !outputs.is_empty() {
                 outputs[0] = plugin.memory_to_val(output);
             }

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -897,8 +897,8 @@ pub(crate) enum GuestRuntime {
 /// ```
 #[macro_export]
 macro_rules! typed_plugin {
-    ($name:ident {$($f:ident $(< $( $lt:tt $( : $clt:path )? ),+ >)? ($input:ty) -> $output:ty);*$(;)?}) => {
-        pub struct $name(pub $crate::Plugin);
+    ($pub:vis $name:ident {$($f:ident $(< $( $lt:tt $( : $clt:path )? ),+ >)? ($input:ty) -> $output:ty);*$(;)?}) => {
+        $pub struct $name(pub $crate::Plugin);
 
         unsafe impl Send for $name {}
         unsafe impl Sync for $name {}

--- a/runtime/src/tests/issues.rs
+++ b/runtime/src/tests/issues.rs
@@ -17,3 +17,12 @@ fn test_issue_620() {
 
     println!("{}", p);
 }
+
+// https://github.com/extism/extism/issues/619
+host_fn!(
+    _resolve_file_path(path: &str) -> String {
+        let path = std::path::PathBuf::from(path);
+        let path = path.canonicalize()?;
+        Ok(path.display().to_string())
+    }
+);

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -8,7 +8,7 @@ const WASM_GLOBALS: &[u8] = include_bytes!("../../../wasm/globals.wasm");
 const WASM_REFLECT: &[u8] = include_bytes!("../../../wasm/reflect.wasm");
 const WASM_HTTP: &[u8] = include_bytes!("../../../wasm/http.wasm");
 
-host_fn!(hello_world (a: String) -> String { Ok(a) });
+host_fn!(pub hello_world (a: String) -> String { Ok(a) });
 
 // Which is the same as:
 // fn hello_world(
@@ -235,7 +235,7 @@ fn test_timeout() {
     assert!(err == "timeout");
 }
 
-typed_plugin!(TestTypedPluginGenerics {
+typed_plugin!(pub TestTypedPluginGenerics {
     count_vowels<T: FromBytes<'a>>(&str) -> T
 });
 


### PR DESCRIPTION
Fixes #619  

- Also updates `host_fn`, `encoding`, and `typed_plugin` macros to allow for visibility specifiers to manage the visibility of the defined types. This means that `pub` will need to be added to existing invocations that should remain public