### PR TITLE
build: add c++ compat to extism.h

### DIFF
--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -16,6 +16,7 @@ fn main() {
         .with_sys_include("stdint.h")
         .with_sys_include("stdbool.h")
         .with_pragma_once(true)
+        .with_cpp_compat(true)
         .with_after_include(fn_macro)
         .rename_item("Size", "ExtismSize")
         .rename_item("ValType", "ExtismValType")

--- a/runtime/extism.h
+++ b/runtime/extism.h
@@ -3,10 +3,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #define EXTISM_FUNCTION(N) extern void N(ExtismCurrentPlugin*, const ExtismVal*, ExtismSize, ExtismVal*, ExtismSize, void*)
 #define EXTISM_GO_FUNCTION(N) extern void N(void*, ExtismVal*, ExtismSize, ExtismVal*, ExtismSize, uintptr_t)
 
@@ -270,7 +266,3 @@ void extism_log_drain(void (*handler)(const char*, uintptr_t));
  * Get the Extism version string
  */
 const char *extism_version(void);
-
-#ifdef __cplusplus
-}
-#endif

--- a/runtime/extism.h
+++ b/runtime/extism.h
@@ -3,6 +3,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define EXTISM_FUNCTION(N) extern void N(ExtismCurrentPlugin*, const ExtismVal*, ExtismSize, ExtismVal*, ExtismSize, void*)
 #define EXTISM_GO_FUNCTION(N) extern void N(void*, ExtismVal*, ExtismSize, ExtismVal*, ExtismSize, uintptr_t)
 
@@ -266,3 +270,7 @@ void extism_log_drain(void (*handler)(const char*, uintptr_t));
  * Get the Extism version string
  */
 const char *extism_version(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/runtime/extism.h
+++ b/runtime/extism.h
@@ -99,6 +99,10 @@ typedef void (*ExtismFunctionType)(ExtismCurrentPlugin *plugin,
 
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 /**
  * Get a plugin's ID, the returned bytes are a 16 byte buffer that represent a UUIDv4
  */
@@ -266,3 +270,7 @@ void extism_log_drain(void (*handler)(const char*, uintptr_t));
  * Get the Extism version string
  */
 const char *extism_version(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus


### PR DESCRIPTION
Before `extern "C"` was needed to include the header in C++ code. Now that's included inside, so it's easier and cleaner to include in c++ projects like the `cpp-sdk`.