### PR TITLE
feat: Add `extism_convert::Raw` to allow direct encoding using bytemuck

### DIFF
--- a/convert/Cargo.toml
+++ b/convert/Cargo.toml
@@ -24,3 +24,4 @@ serde = { version = "1.0.186", features = ["derive"] }
 default = ["msgpack", "protobuf"]
 msgpack = ["rmp-serde"]
 protobuf = ["prost"]
+raw = []

--- a/convert/Cargo.toml
+++ b/convert/Cargo.toml
@@ -12,6 +12,7 @@ description = "Traits to make Rust types usable with Extism"
 [dependencies]
 anyhow = "1.0.75"
 base64 = "~0.21"
+bytemuck = {version = "1.14.0", optional = true }
 prost = { version = "0.12.0", optional = true }
 rmp-serde = { version = "1.1.2", optional = true }
 serde = "1.0.186"
@@ -21,7 +22,7 @@ serde_json = "1.0.105"
 serde = { version = "1.0.186", features = ["derive"] }
 
 [features]
-default = ["msgpack", "protobuf"]
+default = ["msgpack", "protobuf", "raw"]
 msgpack = ["rmp-serde"]
 protobuf = ["prost"]
-raw = []
+raw = ["bytemuck"]

--- a/convert/src/encoding.rs
+++ b/convert/src/encoding.rs
@@ -138,3 +138,86 @@ impl<T: Default + prost::Message> FromBytesOwned for Protobuf<T> {
         Ok(Protobuf(T::decode(data)?))
     }
 }
+
+/// Raw does no conversion, it just copies the memory directly.
+/// Note: This should be used with caution and will not work with any Rust types that use pointers internally or
+// implement `Drop` - it should primarily be used with `repr(C)` structs that embed numeric fields.
+#[cfg(feature = "raw")]
+pub struct Raw<'a, T> {
+    ptr: *const T,
+    _t: std::marker::PhantomData<&'a ()>,
+}
+
+#[cfg(feature = "raw")]
+impl<'a, T> Raw<'a, T> {
+    /// Create a new `Raw` handle from a reference.
+    ///
+    /// # Safety
+    /// This is unsafe because there is no way to statically guarantee that `T` can be copied in an out of memory, as a user
+    /// it is your job to ensure this is only used on structs that don't contain any pointers.
+    pub unsafe fn new(data: &'a T) -> Self {
+        Self {
+            ptr: data as *const T,
+            _t: Default::default(),
+        }
+    }
+
+    /// Get a reference from the `Raw` handle.
+    ///
+    /// # Safety
+    /// There is no guarantee that the resulting value was created from an actual `T`, so even if it was created from the corect
+    /// number of bytes, the layout of the resulting value might not be correct.
+    pub unsafe fn get(&self) -> &T {
+        &*self.ptr
+    }
+}
+
+#[cfg(feature = "raw")]
+impl<'a, T> ToBytes<'a> for Raw<'a, T> {
+    type Bytes = Vec<u8>;
+
+    fn to_bytes(&self) -> Result<Self::Bytes, Error> {
+        let mem = self.ptr as *const u8;
+        let slice = unsafe { std::slice::from_raw_parts(mem, std::mem::size_of::<T>()) };
+        Ok(slice.to_vec())
+    }
+}
+
+#[cfg(feature = "raw")]
+impl<'a, T> FromBytes<'a> for Raw<'a, T> {
+    fn from_bytes(data: &[u8]) -> Result<Self, Error> {
+        if data.len() != std::mem::size_of::<T>() {
+            let name = std::any::type_name::<T>();
+            anyhow::bail!("invalid memory size for Raw type: {}", name);
+        }
+        Ok(Raw {
+            ptr: data.as_ptr() as *const T,
+            _t: Default::default(),
+        })
+    }
+}
+
+#[test]
+#[cfg(feature = "raw")]
+fn test_raw() {
+    #[derive(Debug, Clone, PartialEq)]
+    struct TestRaw {
+        a: i32,
+        b: f64,
+        c: bool,
+    }
+    let x = TestRaw {
+        a: 123,
+        b: 45678.91011,
+        c: true,
+    };
+    let raw = unsafe { Raw::new(&x).to_bytes().unwrap() };
+    let y = Raw::from_bytes(&raw).unwrap();
+    assert_eq!(&x, unsafe { y.get() });
+
+    let y: Result<Raw<[u8; std::mem::size_of::<TestRaw>()]>, Error> = Raw::from_bytes(&raw);
+    assert!(y.is_ok());
+
+    let y: Result<Raw<String>, Error> = Raw::from_bytes(&raw);
+    assert!(y.is_err());
+}

--- a/convert/src/encoding.rs
+++ b/convert/src/encoding.rs
@@ -140,9 +140,7 @@ impl<T: Default + prost::Message> FromBytesOwned for Protobuf<T> {
 }
 
 /// Raw does no conversion, it just copies the memory directly.
-/// Note: This should be used with caution and will not work with any Rust types that use pointers internally or
-// implement `Drop` - it should primarily be used with `repr(C)` structs that embed numeric fields.
-/// See [](https://docs.rs/bytemuck/latest/bytemuck/trait.NoUninit.html#safety)
+/// Note: This will only work for types that implement [bytemuck::Pod](https://docs.rs/bytemuck/latest/bytemuck/trait.Pod.html)
 #[cfg(all(feature = "raw", target_endian = "little"))]
 pub struct Raw<'a, T: bytemuck::Pod>(pub &'a T);
 

--- a/convert/src/lib.rs
+++ b/convert/src/lib.rs
@@ -21,6 +21,9 @@ pub use encoding::Msgpack;
 #[cfg(feature = "protobuf")]
 pub use encoding::Protobuf;
 
+#[cfg(feature = "raw")]
+pub use encoding::Raw;
+
 pub use from_bytes::{FromBytes, FromBytesOwned};
 pub use memory_handle::MemoryHandle;
 pub use to_bytes::ToBytes;

--- a/convert/src/lib.rs
+++ b/convert/src/lib.rs
@@ -21,7 +21,7 @@ pub use encoding::Msgpack;
 #[cfg(feature = "protobuf")]
 pub use encoding::Protobuf;
 
-#[cfg(feature = "raw")]
+#[cfg(all(feature = "raw", target_endian = "little"))]
 pub use encoding::Raw;
 
 pub use from_bytes::{FromBytes, FromBytesOwned};


### PR DESCRIPTION
- Adds `extism_convert::Raw` to encode certain types using their direct memory representations using https://github.com/Lokathor/bytemuck
- Only enabled on little-endian targets to prevent memory mismatch issues 
- Allows for certain types of structs to be encoded using their in-memory representation
- Makes passing structs between Rust and C easier since none of the other encodings are available in C by default.

## Usage
After making a bytemuck-compatible struct:
```rust
use bytemuck::{Zeroable, Pod};

#[derive(Debug, Clone, Copy, PartialEq, Pod, Zeroable)]
#[repr(C)]
struct Point {
  x: i32,
  y: i32,
}
```

It can be used in `call`:

```rust
let input = Point { x: 100, y: 50 };
let Raw(pt): Raw<Point> = plugin.call("transform", Raw(&input))?;
```