### PR TITLE
ci: Release extism.dll.lib and extism.dll.a in the artifacts for Windows users

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,55 +24,55 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: 'macos'
-            target: 'x86_64-apple-darwin'
-            artifact: 'libextism.dylib'
-            static-artifact: 'libextism.a'
-            static-dll-artifact: ''
-            pc-in: 'extism.pc.in'
-            static-pc-in: 'extism-static.pc.in'
-          - os: 'macos'
-            target: 'aarch64-apple-darwin'
-            artifact: 'libextism.dylib'
-            static-artifact: 'libextism.a'
-            static-dll-artifact: ''
-            pc-in: 'extism.pc.in'
-            static-pc-in: 'extism-static.pc.in'
-          - os: 'ubuntu'
-            target: 'aarch64-unknown-linux-gnu'
-            artifact: 'libextism.so'
-            static-artifact: 'libextism.a'
-            static-dll-artifact: ''
-            pc-in: 'extism.pc.in'
-            static-pc-in: 'extism-static.pc.in'
-          - os: 'ubuntu'
-            target: 'aarch64-unknown-linux-musl'
-            artifact: 'libextism.so'
-            static-artifact: 'libextism.a'
-            static-dll-artifact: ''
-            pc-in: 'extism.pc.in'
-            static-pc-in: 'extism-static.pc.in'
-          - os: 'ubuntu'
-            target: 'x86_64-unknown-linux-gnu'
-            artifact: 'libextism.so'
-            static-artifact: 'libextism.a'
-            static-dll-artifact: ''
-            pc-in: 'extism.pc.in'
-            static-pc-in: 'extism-static.pc.in'
-          - os: 'ubuntu'
-            target: 'x86_64-unknown-linux-musl'
-            artifact: ''
-            static-artifact: 'libextism.a'
-            static-dll-artifact: ''
-            pc-in: ''
-            static-pc-in: 'extism-static.pc.in'
-          - os: 'windows'
-            target: 'x86_64-pc-windows-gnu'
-            artifact: 'extism.dll'
-            static-artifact: 'libextism.a'
-            static-dll-artifact: 'extism.dll.a'
-            pc-in: 'extism.pc.in'
-            static-pc-in: 'extism-static.pc.in'
+          # - os: 'macos'
+          #   target: 'x86_64-apple-darwin'
+          #   artifact: 'libextism.dylib'
+          #   static-artifact: 'libextism.a'
+          #   static-dll-artifact: ''
+          #   pc-in: 'extism.pc.in'
+          #   static-pc-in: 'extism-static.pc.in'
+          # - os: 'macos'
+          #   target: 'aarch64-apple-darwin'
+          #   artifact: 'libextism.dylib'
+          #   static-artifact: 'libextism.a'
+          #   static-dll-artifact: ''
+          #   pc-in: 'extism.pc.in'
+          #   static-pc-in: 'extism-static.pc.in'
+          # - os: 'ubuntu'
+          #   target: 'aarch64-unknown-linux-gnu'
+          #   artifact: 'libextism.so'
+          #   static-artifact: 'libextism.a'
+          #   static-dll-artifact: ''
+          #   pc-in: 'extism.pc.in'
+          #   static-pc-in: 'extism-static.pc.in'
+          # - os: 'ubuntu'
+          #   target: 'aarch64-unknown-linux-musl'
+          #   artifact: 'libextism.so'
+          #   static-artifact: 'libextism.a'
+          #   static-dll-artifact: ''
+          #   pc-in: 'extism.pc.in'
+          #   static-pc-in: 'extism-static.pc.in'
+          # - os: 'ubuntu'
+          #   target: 'x86_64-unknown-linux-gnu'
+          #   artifact: 'libextism.so'
+          #   static-artifact: 'libextism.a'
+          #   static-dll-artifact: ''
+          #   pc-in: 'extism.pc.in'
+          #   static-pc-in: 'extism-static.pc.in'
+          # - os: 'ubuntu'
+          #   target: 'x86_64-unknown-linux-musl'
+          #   artifact: ''
+          #   static-artifact: 'libextism.a'
+          #   static-dll-artifact: ''
+          #   pc-in: ''
+          #   static-pc-in: 'extism-static.pc.in'
+          # - os: 'windows'
+          #   target: 'x86_64-pc-windows-gnu'
+          #   artifact: 'extism.dll'
+          #   static-artifact: 'libextism.a'
+          #   static-dll-artifact: 'extism.dll.a'
+          #   pc-in: 'extism.pc.in'
+          #   static-pc-in: 'extism-static.pc.in'
           - os: 'windows'
             target: 'x86_64-pc-windows-msvc'
             artifact: 'extism.dll'
@@ -145,17 +145,18 @@ jobs:
           sccache: 'true'
           manylinux: 2_28
 
-      - name: Add pkg-config files except on MSVC
-        if: ${{ matrix.target != 'x86_64-pc-windows-msvc' }}
-        shell: bash
-        run: |
-          SRC_DIR=target/${{ matrix.target }}/release
-          cp libextism/extism*.pc.in ${SRC_DIR}
+      # - name: Add pkg-config files except on MSVC
+      #   if: ${{ matrix.target != 'x86_64-pc-windows-msvc' }}
+      #   shell: bash
+      #   run: |
+      #     SRC_DIR=target/${{ matrix.target }}/release
+      #     cp libextism/extism*.pc.in ${SRC_DIR}
 
       - name: Prepare Artifact
         shell: bash
         run: |
           SRC_DIR=target/${{ matrix.target }}/release
+          ls SRC_DIR
           DEST_DIR=${{ env.ARTIFACT_DIR }}
           RELEASE_NAME=libextism-${{ matrix.target }}-${{ github.ref_name }}
           ARCHIVE=${RELEASE_NAME}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
         shell: bash
         run: |
           SRC_DIR=target/${{ matrix.target }}/release
-          ls SRC_DIR
+          ls ${SRC_DIR}
           DEST_DIR=${{ env.ARTIFACT_DIR }}
           RELEASE_NAME=libextism-${{ matrix.target }}-${{ github.ref_name }}
           ARCHIVE=${RELEASE_NAME}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,31 +119,31 @@ jobs:
           command: build
           args: --release --target ${{ matrix.target }} -p ${{ env.RUNTIME_CRATE }}
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
+      # - uses: actions/setup-python@v4
+      #   with:
+      #     python-version: '3.10'
 
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        # maturin's cffi integration struggles with gnu headers on windows.
-        # there's partial work towards fixing this in `extism-maturin/build.rs`, but it's
-        # not sufficient to get it to work. omit it for now!
-        if: ${{ matrix.target != 'x86_64-pc-windows-gnu' && matrix.target != 'aarch64-unknown-linux-gnu' }}
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter -m extism-maturin/Cargo.toml
-          sccache: 'true'
-          manylinux: auto
+      # - name: Build wheels
+      #   uses: PyO3/maturin-action@v1
+      #   # maturin's cffi integration struggles with gnu headers on windows.
+      #   # there's partial work towards fixing this in `extism-maturin/build.rs`, but it's
+      #   # not sufficient to get it to work. omit it for now!
+      #   if: ${{ matrix.target != 'x86_64-pc-windows-gnu' && matrix.target != 'aarch64-unknown-linux-gnu' }}
+      #   with:
+      #     target: ${{ matrix.target }}
+      #     args: --release --out dist --find-interpreter -m extism-maturin/Cargo.toml
+      #     sccache: 'true'
+      #     manylinux: auto
 
-      - name: Build GNU Linux wheels
-        uses: PyO3/maturin-action@v1
-        # One of our deps, "ring", needs a newer sysroot than what "manylinux: auto" provides.
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter -m extism-maturin/Cargo.toml
-          sccache: 'true'
-          manylinux: 2_28
+      # - name: Build GNU Linux wheels
+      #   uses: PyO3/maturin-action@v1
+      #   # One of our deps, "ring", needs a newer sysroot than what "manylinux: auto" provides.
+      #   if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
+      #   with:
+      #     target: ${{ matrix.target }}
+      #     args: --release --out dist --find-interpreter -m extism-maturin/Cargo.toml
+      #     sccache: 'true'
+      #     manylinux: 2_28
 
       # - name: Add pkg-config files except on MSVC
       #   if: ${{ matrix.target != 'x86_64-pc-windows-msvc' }}
@@ -157,6 +157,11 @@ jobs:
         run: |
           SRC_DIR=target/${{ matrix.target }}/release
           ls ${SRC_DIR}
+          echo 'tar -C ${SRC_DIR} -czvf ${ARCHIVE} extism.h \
+            ${{ matrix.artifact }} ${{ matrix.static-artifact }}  \
+            ${{ matrix.pc-in }} ${{ matrix.static-pc-in }} \
+            ${{ matrix.static-dll-artifact }}'
+
           DEST_DIR=${{ env.ARTIFACT_DIR }}
           RELEASE_NAME=libextism-${{ matrix.target }}-${{ github.ref_name }}
           ARCHIVE=${RELEASE_NAME}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,48 +28,56 @@ jobs:
             target: 'x86_64-apple-darwin'
             artifact: 'libextism.dylib'
             static-artifact: 'libextism.a'
+            static-dll-artifact: ''
             pc-in: 'extism.pc.in'
             static-pc-in: 'extism-static.pc.in'
           - os: 'macos'
             target: 'aarch64-apple-darwin'
             artifact: 'libextism.dylib'
             static-artifact: 'libextism.a'
+            static-dll-artifact: ''
             pc-in: 'extism.pc.in'
             static-pc-in: 'extism-static.pc.in'
           - os: 'ubuntu'
             target: 'aarch64-unknown-linux-gnu'
             artifact: 'libextism.so'
             static-artifact: 'libextism.a'
+            static-dll-artifact: ''
             pc-in: 'extism.pc.in'
             static-pc-in: 'extism-static.pc.in'
           - os: 'ubuntu'
             target: 'aarch64-unknown-linux-musl'
             artifact: 'libextism.so'
             static-artifact: 'libextism.a'
+            static-dll-artifact: ''
             pc-in: 'extism.pc.in'
             static-pc-in: 'extism-static.pc.in'
           - os: 'ubuntu'
             target: 'x86_64-unknown-linux-gnu'
             artifact: 'libextism.so'
             static-artifact: 'libextism.a'
+            static-dll-artifact: ''
             pc-in: 'extism.pc.in'
             static-pc-in: 'extism-static.pc.in'
           - os: 'ubuntu'
             target: 'x86_64-unknown-linux-musl'
             artifact: ''
             static-artifact: 'libextism.a'
+            static-dll-artifact: ''
             pc-in: ''
             static-pc-in: 'extism-static.pc.in'
           - os: 'windows'
             target: 'x86_64-pc-windows-gnu'
             artifact: 'extism.dll'
             static-artifact: 'libextism.a'
+            static-dll-artifact: 'extism.dll.a'
             pc-in: 'extism.pc.in'
             static-pc-in: 'extism-static.pc.in'
           - os: 'windows'
             target: 'x86_64-pc-windows-msvc'
             artifact: 'extism.dll'
             static-artifact: 'extism.lib'
+            static-dll-artifact: 'extism.dll.lib'
             pc-in: ''
             static-pc-in: ''
 
@@ -158,7 +166,8 @@ jobs:
           cp LICENSE ${SRC_DIR}
           tar -C ${SRC_DIR} -czvf ${ARCHIVE} extism.h \
             ${{ matrix.artifact }} ${{ matrix.static-artifact }}  \
-            ${{ matrix.pc-in }} ${{ matrix.static-pc-in }}
+            ${{ matrix.pc-in }} ${{ matrix.static-pc-in }} \
+            ${{ matrix.static-dll-artifact }}
           ls -ll ${ARCHIVE}
 
           if &>/dev/null which shasum; then
@@ -186,32 +195,32 @@ jobs:
           name: ${{ env.ARTIFACT_DIR }}
           path: ${{ env.ARTIFACT_DIR }}
 
-      - name: Upload Artifact to Draft Release
-        uses: softprops/action-gh-release@v1
-        with:
-          draft: true
-          files: |
-            ${{ env.ARTIFACT_DIR }}/*
-        if: startsWith(github.ref, 'refs/tags/')
+  #     - name: Upload Artifact to Draft Release
+  #       uses: softprops/action-gh-release@v1
+  #       with:
+  #         draft: true
+  #         files: |
+  #           ${{ env.ARTIFACT_DIR }}/*
+  #       if: startsWith(github.ref, 'refs/tags/')
 
-  release-latest:
-    name: create latest release
-    runs-on: ubuntu-latest
-    needs: [release]
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{ env.ARTIFACT_DIR }}
+  # release-latest:
+  #   name: create latest release
+  #   runs-on: ubuntu-latest
+  #   needs: [release]
+  #   if: github.ref == 'refs/heads/main'
+  #   steps:
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: ${{ env.ARTIFACT_DIR }}
 
-      - uses: "marvinpinto/action-automatic-releases@latest"
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest"
-          prerelease: true
-          title: "Development Build"
-          files: |
-            *.tar.gz
-            *.txt
-            *.whl
-        if: github.ref == 'refs/heads/main'
+  #     - uses: "marvinpinto/action-automatic-releases@latest"
+  #       with:
+  #         repo_token: "${{ secrets.GITHUB_TOKEN }}"
+  #         automatic_release_tag: "latest"
+  #         prerelease: true
+  #         title: "Development Build"
+  #         files: |
+  #           *.tar.gz
+  #           *.txt
+  #           *.whl
+  #       if: github.ref == 'refs/heads/main'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,18 +85,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set version
-        shell: bash
-        run: |
-          version="${{ github.ref }}"
-          if [[ "$version" = "refs/heads/main" ]]; then
-            version="0.0.0-dev"
-          else
-            version="${version/refs\/tags\/v/}"
-          fi
-          sed -i -e "s/0.0.0+replaced-by-ci/${version}/g" Cargo.toml
-          pyproject="$(cat extism-maturin/pyproject.toml)"
-          <<<"$pyproject" >extism-maturin/pyproject.toml sed -e 's/^version = "0.0.0.replaced-by-ci"/version = "'"$version"'"/g'
+      # - name: Set version
+      #   shell: bash
+      #   run: |
+      #     version="${{ github.ref }}"
+      #     if [[ "$version" = "refs/heads/main" ]]; then
+      #       version="0.0.0-dev"
+      #     else
+      #       version="${version/refs\/tags\/v/}"
+      #     fi
+      #     sed -i -e "s/0.0.0+replaced-by-ci/${version}/g" Cargo.toml
+      #     pyproject="$(cat extism-maturin/pyproject.toml)"
+      #     <<<"$pyproject" >extism-maturin/pyproject.toml sed -e 's/^version = "0.0.0.replaced-by-ci"/version = "'"$version"'"/g'
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
`extism.dll.lib` includes the imports for `extism.dll` and is necessary for MSVC if the user wants to link dynamically to extism.dll. This file is already generated by the build process, we just need to bundle it in the artifacts


Related to #141 