### PR TITLE
fix: give extism_log_drain's param a named type

### DIFF
--- a/runtime/extism.h
+++ b/runtime/extism.h
@@ -97,6 +97,11 @@ typedef void (*ExtismFunctionType)(ExtismCurrentPlugin *plugin,
                                    ExtismSize n_outputs,
                                    void *data);
 
+/**
+ * Log drain callback
+ */
+typedef void (*ExtismLogDrainFunctionType)(const char *data, ExtismSize size);
+
 
 
 #ifdef __cplusplus
@@ -264,7 +269,7 @@ bool extism_log_custom(const char *log_level);
  * Calls the provided callback function for each buffered log line.
  * This is only needed when `extism_log_custom` is used.
  */
-void extism_log_drain(void (*handler)(const char*, uintptr_t));
+void extism_log_drain(ExtismLogDrainFunctionType handler);
 
 /**
  * Reset the Extism runtime, this will invalidate all allocated memory


### PR DESCRIPTION
This fixes a test failure on the python-sdk [1]. (See also [2]). In particular, while maturin creates bindings for `extism_log_drain` on clang platforms, it seems that MSVC cannot generate the required binding information for `ffi.py`. This results in an `extism_sys` wheel whose shared object (in this case, a DLL) contains the `extism_log_drain`, but whose Python FFI bindings don't contain a definition for that function.

Naming the function pointer type parameter resolves the issue. What a strange issue!

[1]: https://github.com/extism/python-sdk/actions/runs/7172934060/job/19669775001#step:9:35
[2]: https://github.com/extism/python-sdk/pull/18#issuecomment-1850892835