### PR TITLE
Toggle off default `clap` feature for `cbindgen`

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -33,7 +33,7 @@ register-filesystem = [] # enables wasm to be loaded from disk
 http = ["ureq"]          # enables extism_http_request
 
 [build-dependencies]
-cbindgen = "0.26"
+cbindgen = { version = "0.26", default-features = false }
 
 [dev-dependencies]
 criterion = "0.5.1"


### PR DESCRIPTION
The only feature for `cbindgen` is the `clap` feature for using it as a standalone binary and isn't needed when using it as a library