### PR TITLE
Make function Plugin::function_extists check the type of the functions.

### DIFF
--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -403,7 +403,18 @@ impl Plugin {
     pub fn function_exists(&mut self, function: impl AsRef<str>) -> bool {
         self.modules[MAIN_KEY]
             .get_export(function.as_ref())
-            .map(|x| x.func().is_some())
+            .map(|x| {
+                if let Some(f) = x.func() {
+                    let (params, mut results) = (f.params(), f.results());
+                    match (params.len(), results.len()) {
+                        (0, 1) => results.next() == Some(wasmtime::ValType::I32),
+                        (0, 0) => true,
+                        _ => false,
+                    }
+                } else {
+                    false
+                }
+            })
             .unwrap_or(false)
     }
 


### PR DESCRIPTION
This PR addresses #654
It checks the parameters and results of the function as described in the mentioned issue.