### PR TITLE
refactor!: use wasi preview2

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-wasmtime = ">= 14.0.0, < 18.0.0"
-wasmtime-wasi = ">= 14.0.0, < 18.0.0"
+wasmtime = ">= 17.0.0, < 18.0.0"
+wasmtime-wasi = ">= 17.0.0, < 18.0.0"
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-wasmtime = ">= 17.0.0, < 18.0.0"
-wasmtime-wasi = ">= 17.0.0, < 18.0.0"
+wasmtime = ">= 18.0.0, < 19.0.0"
+wasmtime-wasi = ">= 18.0.0, < 19.0.0"
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -1,3 +1,6 @@
+use wasmtime::component::ResourceTable;
+use wasmtime_wasi::preview2::{preview1::WasiPreview1Adapter, DirPerms, FilePerms};
+
 use crate::*;
 
 /// CurrentPlugin stores data that is available to the caller in PDK functions, this should
@@ -18,6 +21,7 @@ pub struct CurrentPlugin {
 }
 
 unsafe impl Send for CurrentPlugin {}
+unsafe impl Sync for CurrentPlugin {}
 
 pub(crate) struct MemoryLimiter {
     bytes_left: usize,
@@ -294,10 +298,10 @@ impl CurrentPlugin {
     ) -> Result<Self, Error> {
         let wasi = if wasi {
             let auth = wasmtime_wasi::ambient_authority();
-            let mut ctx = wasmtime_wasi::WasiCtxBuilder::new();
-            for (k, v) in manifest.config.iter() {
-                ctx.env(k, v)?;
-            }
+            let mut ctx = wasmtime_wasi::preview2::WasiCtxBuilder::new();
+            ctx.allow_ip_name_lookup(true);
+            ctx.allow_tcp(true);
+            ctx.allow_udp(true);
 
             if let Some(a) = &manifest.allowed_paths {
                 for (k, v) in a.iter() {
@@ -308,8 +312,31 @@ impl CurrentPlugin {
                             err.kind()
                         ))
                     })?;
-                    ctx.preopened_dir(d, v)?;
+                    ctx.preopened_dir(
+                        d,
+                        DirPerms::READ | DirPerms::MUTATE,
+                        FilePerms::READ | FilePerms::WRITE,
+                        v.to_string_lossy(),
+                    );
                 }
+            }
+
+            if let Some(h) = &manifest.allowed_hosts {
+                let h = h.clone();
+                ctx.socket_addr_check(move |addr, _kind| {
+                    for host in h.iter() {
+                        let addrs = std::net::ToSocketAddrs::to_socket_addrs(&host);
+                        if let Ok(addrs) = addrs {
+                            for a in addrs.into_iter() {
+                                if addr == &a {
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+
+                    false
+                });
             }
 
             // Enable WASI output, typically used for debugging purposes
@@ -317,7 +344,11 @@ impl CurrentPlugin {
                 ctx.inherit_stdout().inherit_stderr();
             }
 
-            Some(Wasi { ctx: ctx.build() })
+            Some(Wasi {
+                ctx: ctx.build(),
+                preview2_table: ResourceTable::new(),
+                preview1_adapter: WasiPreview1Adapter::new(),
+            })
         } else {
             None
         };

--- a/runtime/src/internal.rs
+++ b/runtime/src/internal.rs
@@ -3,7 +3,36 @@ use crate::*;
 /// WASI context
 pub struct Wasi {
     /// wasi
-    pub ctx: wasmtime_wasi::WasiCtx,
+    pub ctx: wasmtime_wasi::preview2::WasiCtx,
+    pub preview2_table: wasmtime::component::ResourceTable,
+    pub preview1_adapter: wasmtime_wasi::preview2::preview1::WasiPreview1Adapter,
+}
+
+impl wasmtime_wasi::preview2::WasiView for CurrentPlugin {
+    fn table_mut(&mut self) -> &mut wasmtime::component::ResourceTable {
+        &mut self.wasi.as_mut().unwrap().preview2_table
+    }
+
+    fn table(&self) -> &wasmtime::component::ResourceTable {
+        &self.wasi.as_ref().unwrap().preview2_table
+    }
+
+    fn ctx(&self) -> &wasmtime_wasi::preview2::WasiCtx {
+        &self.wasi.as_ref().unwrap().ctx
+    }
+    fn ctx_mut(&mut self) -> &mut wasmtime_wasi::preview2::WasiCtx {
+        &mut self.wasi.as_mut().unwrap().ctx
+    }
+}
+
+impl wasmtime_wasi::preview2::preview1::WasiPreview1View for CurrentPlugin {
+    fn adapter(&self) -> &wasmtime_wasi::preview2::preview1::WasiPreview1Adapter {
+        &self.wasi.as_ref().unwrap().preview1_adapter
+    }
+
+    fn adapter_mut(&mut self) -> &mut wasmtime_wasi::preview2::preview1::WasiPreview1Adapter {
+        &mut self.wasi.as_mut().unwrap().preview1_adapter
+    }
 }
 
 /// InternalExt provides a unified way of acessing `memory`, `store` and `internal` values

--- a/runtime/src/internal.rs
+++ b/runtime/src/internal.rs
@@ -9,18 +9,11 @@ pub struct Wasi {
 }
 
 impl wasmtime_wasi::preview2::WasiView for CurrentPlugin {
-    fn table_mut(&mut self) -> &mut wasmtime::component::ResourceTable {
+    fn table(&mut self) -> &mut wasmtime::component::ResourceTable {
         &mut self.wasi.as_mut().unwrap().preview2_table
     }
 
-    fn table(&self) -> &wasmtime::component::ResourceTable {
-        &self.wasi.as_ref().unwrap().preview2_table
-    }
-
-    fn ctx(&self) -> &wasmtime_wasi::preview2::WasiCtx {
-        &self.wasi.as_ref().unwrap().ctx
-    }
-    fn ctx_mut(&mut self) -> &mut wasmtime_wasi::preview2::WasiCtx {
+    fn ctx(&mut self) -> &mut wasmtime_wasi::preview2::WasiCtx {
         &mut self.wasi.as_mut().unwrap().ctx
     }
 }

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -307,9 +307,7 @@ impl Plugin {
 
         // If wasi is enabled then add it to the linker
         if with_wasi {
-            wasmtime_wasi::add_to_linker(&mut linker, |x: &mut CurrentPlugin| {
-                &mut x.wasi.as_mut().unwrap().ctx
-            })?;
+            wasmtime_wasi::preview2::preview1::add_to_linker_sync(&mut linker)?;
         }
 
         for f in &mut imports {

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -803,12 +803,8 @@ impl Plugin {
                 }
 
                 let wasi_exit_code = e
-                    .downcast_ref::<wasmtime_wasi::I32Exit>()
-                    .map(|e| e.0)
-                    .or_else(|| {
-                        e.downcast_ref::<wasmtime_wasi::preview2::I32Exit>()
-                            .map(|e| e.0)
-                    });
+                    .downcast_ref::<wasmtime_wasi::preview2::I32Exit>()
+                    .map(|e| e.0);
                 if let Some(exit_code) = wasi_exit_code {
                     debug!(
                         plugin = self.id.to_string(),

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -389,20 +389,6 @@ pub unsafe extern "C" fn extism_plugin_config(
             }
         };
 
-    let wasi = &mut plugin.current_plugin_mut().wasi;
-    if let Some(Wasi { ctx, .. }) = wasi {
-        for (k, v) in json.iter() {
-            match v {
-                Some(v) => {
-                    let _ = ctx.push_env(k, v);
-                }
-                None => {
-                    let _ = ctx.push_env(k, "");
-                }
-            }
-        }
-    }
-
     let id = plugin.id;
     let config = &mut plugin.current_plugin_mut().manifest.config;
     for (k, v) in json.into_iter() {


### PR DESCRIPTION
- Breaking: No longer copies Extism config values into WASI environment variables, these should be accessed using the Extism config functions instead
- Requires wasmtime 17 or greater
- Allows WASI TCP/UDP requests to hosts listed in the `allowed_hosts` field of the manifest
- Adds support for wasi-preview2
