### PR TITLE
feat: allow max HTTP response size to be configured in the manifest

### DIFF
--- a/manifest/schema.json
+++ b/manifest/schema.json
@@ -37,6 +37,7 @@
     "memory": {
       "description": "Memory options",
       "default": {
+        "max_http_response_bytes": null,
         "max_pages": null
       },
       "allOf": [
@@ -70,6 +71,16 @@
       "description": "Configure memory settings",
       "type": "object",
       "properties": {
+        "max_http_response_bytes": {
+          "description": "The maximum number of bytes allowed in an HTTP response",
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "max_pages": {
           "description": "The max number of WebAssembly pages that should be allocated",
           "type": [

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -12,6 +12,10 @@ pub struct MemoryOptions {
     /// The max number of WebAssembly pages that should be allocated
     #[serde(alias = "max")]
     pub max_pages: Option<u32>,
+
+    /// The maximum number of bytes allowed in an HTTP response
+    #[serde(default)]
+    pub max_http_response_bytes: Option<u64>,
 }
 
 /// Generic HTTP request structure
@@ -225,6 +229,7 @@ pub struct Manifest {
     /// WebAssembly modules, the `main` module should be named `main` or listed last
     #[serde(default)]
     pub wasm: Vec<Wasm>,
+
     /// Memory options
     #[serde(default)]
     pub memory: MemoryOptions,

--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -237,9 +237,11 @@ pub(crate) fn http_request(
 
         if let Some(reader) = reader {
             let mut buf = Vec::new();
-            reader
-                .take(1024 * 1024 * 50) // TODO: make this limit configurable
-                .read_to_end(&mut buf)?;
+            if let Some(max) = &data.manifest.memory.max_http_response_bytes {
+                reader.take(*max).read_to_end(&mut buf)?;
+            } else {
+                reader.take(1024 * 1024 * 50).read_to_end(&mut buf)?;
+            }
 
             let mem = data.memory_new(&buf)?;
             output[0] = Val::I64(mem.offset() as i64);

--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -237,10 +237,16 @@ pub(crate) fn http_request(
 
         if let Some(reader) = reader {
             let mut buf = Vec::new();
-            if let Some(max) = &data.manifest.memory.max_http_response_bytes {
-                reader.take(*max).read_to_end(&mut buf)?;
+            let max = if let Some(max) = &data.manifest.memory.max_http_response_bytes {
+                reader.take(*max + 1).read_to_end(&mut buf)?;
+                *max
             } else {
-                reader.take(1024 * 1024 * 50).read_to_end(&mut buf)?;
+                reader.take(1024 * 1024 * 50 + 1).read_to_end(&mut buf)?;
+                1024 * 1024 * 50
+            };
+
+            if buf.len() > max as usize {
+                anyhow::bail!("HTTP response exceeds the configured maximum number of bytes: {max}")
             }
 
             let mem = data.memory_new(&buf)?;


### PR DESCRIPTION
- Adds `memory.max_http_response_bytes` field to specify the maximum size of an HTTP request response