### PR TITLE
fix: linker issue that depends on the ordering of the linked functions

### DIFF
--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -249,13 +249,6 @@ impl Plugin {
             })?;
         }
 
-        let main = &modules[MAIN_KEY];
-        for (name, module) in modules.iter() {
-            if name != MAIN_KEY {
-                linker.module(&mut store, name, module)?;
-            }
-        }
-
         let mut imports: Vec<_> = imports.into_iter().collect();
         // Define PDK functions
         macro_rules! add_funcs {
@@ -286,6 +279,13 @@ impl Plugin {
             let ns = f.namespace().unwrap_or(EXTISM_USER_MODULE);
             unsafe {
                 linker.func_new(ns, &name, f.ty().clone(), &*(f.f.as_ref() as *const _))?;
+            }
+        }
+
+        let main = &modules[MAIN_KEY];
+        for (name, module) in modules.iter() {
+            if name != MAIN_KEY {
+                linker.module(&mut store, name, module)?;
             }
         }
 

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -295,12 +295,13 @@ impl Plugin {
             for import in module.imports() {
                 if !linked.contains(import.module()) {
                     if let Some(m) = modules.get(import.module()) {
-                        linked.insert(import.module());
                         linker.module(&mut store, name, m)?;
+                        linked.insert(import.module());
                     }
                 }
             }
             linker.module(&mut store, name, module)?;
+            linked.insert(name);
         }
 
         let main = &modules[MAIN_KEY];

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -301,10 +301,11 @@ impl Plugin {
             log_error(I64);
         );
 
-        // If wasi is enabled then add it to the linker
         let mut linked = BTreeSet::new();
         linker.module(&mut store, EXTISM_ENV_MODULE, &modules[EXTISM_ENV_MODULE])?;
         linked.insert(EXTISM_ENV_MODULE.to_string());
+
+        // If wasi is enabled then add it to the linker
         if with_wasi {
             wasmtime_wasi::add_to_linker(&mut linker, |x: &mut CurrentPlugin| {
                 &mut x.wasi.as_mut().unwrap().ctx

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -658,6 +658,6 @@ fn test_linking() {
         .unwrap();
 
     for _ in 0..5 {
-        assert!(plugin.call::<&str, i64>("run", "Hello, world!").is_ok());
+        assert_eq!(plugin.call::<&str, i64>("run", "Hello, world!").unwrap(), 1);
     }
 }

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -593,3 +593,71 @@ fn test_manifest_ptr_len() {
     let count: serde_json::Value = serde_json::from_slice(output).unwrap();
     assert_eq!(count.get("count").unwrap().as_i64().unwrap(), 1);
 }
+
+#[test]
+fn test_linking() {
+    let manifest = Manifest::new([
+        Wasm::Data {
+            data: br#"
+                (module
+                    (import "wasi_snapshot_preview1" "random_get" (func $random (param i32 i32) (result i32)))
+                    (import "extism:host/env" "alloc" (func $alloc (param i64) (result i64)))
+                    (import "extism:host/user" "hello" (func $hello))
+                    (global $counter (mut i32) (i32.const 0))
+                    (func $start (export "_start")
+                        (global.set $counter (i32.add (global.get $counter) (i32.const 1)))
+                    )
+                    (func (export "read_counter") (result i32)
+                        (global.get $counter)
+                    )
+                    (start $start)
+                )
+            "#.to_vec(),
+            meta: WasmMetadata {
+                name: Some("commander".to_string()),
+                hash: None,
+            },
+        },
+        Wasm::Data {
+            data: br#"
+                (module
+                    (import "commander" "_start" (func $commander_start))
+                    (import "commander" "read_counter" (func $commander_read_counter (result i32)))
+                    (import "extism:host/env" "store_u64" (func $store_u64 (param i64 i64)))
+                    (import "extism:host/env" "alloc" (func $alloc (param i64) (result i64)))
+                    (import "extism:host/user" "hello" (func $hello))
+                    (import "extism:host/env" "output_set" (func $output_set (param i64 i64)))
+                    (func (export "run") (result i32)
+                        (local $output i64)
+                        (local.set $output (call $alloc (i64.const 8)))
+
+                        (call $commander_start)
+                        (call $commander_start)
+                        (call $commander_start)
+                        (call $commander_start)
+                        (call $hello)
+                        (call $store_u64 (local.get $output) (i64.extend_i32_u (call $commander_read_counter)))
+                        (call $output_set (local.get $output) (i64.const 8))
+                        i32.const 0
+                    )
+                )
+            "#.to_vec(),
+            meta: WasmMetadata {
+                name: Some("main".to_string()),
+                hash: None,
+            },
+        },
+    ]);
+    let mut plugin = PluginBuilder::new(manifest)
+        .with_wasi(true)
+        .with_function("hello", [], [], UserData::new(()), |_, _, _, _| {
+            eprintln!("hello!");
+            Ok(())
+        })
+        .build()
+        .unwrap();
+
+    for _ in 0..5 {
+        assert!(plugin.call::<&str, i64>("run", "Hello, world!").is_ok());
+    }
+}


### PR DESCRIPTION
It looks like when a module is added to the linker, all of its imports must already be present. This PR updates the linking process to take that into consideration and adds a test with a reproduction of the issue @chrisdickinson shared with me. 