### PR TITLE
feat: add ability to configure size of the Extism var store

### DIFF
--- a/manifest/schema.json
+++ b/manifest/schema.json
@@ -38,7 +38,8 @@
       "description": "Memory options",
       "default": {
         "max_http_response_bytes": null,
-        "max_pages": null
+        "max_pages": null,
+        "max_var_bytes": null
       },
       "allOf": [
         {
@@ -88,6 +89,16 @@
             "null"
           ],
           "format": "uint32",
+          "minimum": 0.0
+        },
+        "max_var_bytes": {
+          "description": "The maximum number of bytes allowed to be used by plugin vars. Setting this to 0 will disable Extism vars. The default value is 1mb.",
+          "default": 1048576,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
           "minimum": 0.0
         }
       },

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -23,6 +23,31 @@ pub struct MemoryOptions {
     pub max_var_bytes: Option<u64>,
 }
 
+impl MemoryOptions {
+    /// Create an empty `MemoryOptions` value
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Set max pages
+    pub fn with_max_pages(mut self, pages: u32) -> Self {
+        self.max_pages = Some(pages);
+        self
+    }
+
+    /// Set max HTTP response size
+    pub fn with_max_http_response_bytes(mut self, bytes: u64) -> Self {
+        self.max_http_response_bytes = Some(bytes);
+        self
+    }
+
+    /// Set max size of Extism vars
+    pub fn with_max_var_bytes(mut self, bytes: u64) -> Self {
+        self.max_var_bytes = Some(bytes);
+        self
+    }
+}
+
 fn default_var_bytes() -> Option<u64> {
     Some(1024 * 1024)
 }

--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -16,6 +16,15 @@ pub struct MemoryOptions {
     /// The maximum number of bytes allowed in an HTTP response
     #[serde(default)]
     pub max_http_response_bytes: Option<u64>,
+
+    /// The maximum number of bytes allowed to be used by plugin vars. Setting this to 0
+    /// will disable Extism vars. The default value is 1mb.
+    #[serde(default = "default_var_bytes")]
+    pub max_var_bytes: Option<u64>,
+}
+
+fn default_var_bytes() -> Option<u64> {
+    Some(1024 * 1024)
 }
 
 /// Generic HTTP request structure

--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -104,8 +104,8 @@ pub(crate) fn var_set(
 
     let voffset = args!(input, 1, i64) as u64;
 
-    // If the store is larger than 100MB then stop adding things
-    if size > 1024 * 1024 * 100 && voffset != 0 {
+    // If the store is larger than the configured size, or 1mb by default, then stop adding things
+    if size > data.manifest.memory.max_var_bytes.unwrap_or(1024 * 1024) as usize && voffset != 0 {
         return Err(Error::msg("Variable store is full"));
     }
 

--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -98,7 +98,8 @@ pub(crate) fn var_set(
     let data: &mut CurrentPlugin = caller.data_mut();
 
     let mut size = 0;
-    for v in data.vars.values() {
+    for (k, v) in data.vars.iter() {
+        size += k.len();
         size += v.len();
     }
 

--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -110,6 +110,7 @@ pub(crate) fn var_set(
         let key_ptr = key.as_ptr();
         unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(key_ptr, key_len)) }
     };
+
     // Remove if the value offset is 0
     if voffset == 0 {
         data.vars.remove(key);
@@ -121,10 +122,15 @@ pub(crate) fn var_set(
         None => anyhow::bail!("invalid handle offset for var value: {voffset}"),
     };
 
-    let mut size = key.len() + handle.length as usize;
+    let mut size = std::mem::size_of::<String>()
+        + std::mem::size_of::<Vec<u8>>()
+        + key.len()
+        + handle.length as usize;
+
     for (k, v) in data.vars.iter() {
         size += k.len();
         size += v.len();
+        size += std::mem::size_of::<String>() + std::mem::size_of::<Vec<u8>>();
     }
 
     // If the store is larger than the configured size, or 1mb by default, then stop adding things

--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -97,6 +97,10 @@ pub(crate) fn var_set(
 ) -> Result<(), Error> {
     let data: &mut CurrentPlugin = caller.data_mut();
 
+    if data.manifest.memory.max_var_bytes.is_some_and(|x| x == 0) {
+        anyhow::bail!("Vars are disabled by this host")
+    }
+
     let voffset = args!(input, 1, i64) as u64;
     let key_offs = args!(input, 0, i64) as u64;
 


### PR DESCRIPTION
- Adds `memory.max_var_bytes` to the manifest to limit the number of bytes allowed to be stored in Extism vars - if `max_var_bytes` is set to 0 then vars are disabled.
- Adds some builder functions to `MemoryOptions` struct
- Sets the default var store size to 1mb
- Includes a test to make sure `var_set` returns an error when the limit is reached