### PR TITLE
chore: update badge to reflect rust installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Discord](https://img.shields.io/discord/1011124058408112148?color=%23404eed&label=Community%20Chat&logo=Discord&logoColor=%23404eed)](https://extism.org/discord)
 ![GitHub Org's stars](https://img.shields.io/github/stars/extism)
-![GitHub all releases](https://img.shields.io/github/downloads/extism/extism/total)
+![Downloads](https://img.shields.io/crates/d/extism)
 ![GitHub License](https://img.shields.io/github/license/extism/extism)
 ![GitHub release (with filter)](https://img.shields.io/github/v/release/extism/extism)
 


### PR DESCRIPTION
Still under-representing, but a better representation of Extism downloads