### PR TITLE
feat: add Pool type for pooling plugin instances

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -26,6 +26,7 @@ extism-manifest = { workspace = true }
 extism-convert = { workspace = true, features = ["extism-path"] }
 uuid = { version = "1", features = ["v4"] }
 libc = "0.2"
+dashmap = "5.5.3"
 
 [features]
 default = ["http", "register-http", "register-filesystem"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -26,7 +26,6 @@ extism-manifest = { workspace = true }
 extism-convert = { workspace = true, features = ["extism-path"] }
 uuid = { version = "1", features = ["v4"] }
 libc = "0.2"
-dashmap = "5.5.3"
 
 [features]
 default = ["http", "register-http", "register-filesystem"]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -44,7 +44,7 @@ pub use plugin::{
     CancelHandle, CompiledPlugin, Plugin, WasmInput, EXTISM_ENV_MODULE, EXTISM_USER_MODULE,
 };
 pub use plugin_builder::{DebugOptions, PluginBuilder};
-pub use pool::{Pool, PoolPlugin};
+pub use pool::{Pool, PoolBuilder, PoolPlugin};
 
 pub(crate) use internal::{Internal, Wasi};
 pub(crate) use timer::{Timer, TimerAction};

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -29,6 +29,7 @@ pub(crate) mod manifest;
 pub(crate) mod pdk;
 mod plugin;
 mod plugin_builder;
+mod pool;
 mod readonly_dir;
 mod timer;
 
@@ -43,6 +44,7 @@ pub use plugin::{
     CancelHandle, CompiledPlugin, Plugin, WasmInput, EXTISM_ENV_MODULE, EXTISM_USER_MODULE,
 };
 pub use plugin_builder::{DebugOptions, PluginBuilder};
+pub use pool::Pool;
 
 pub(crate) use internal::{Internal, Wasi};
 pub(crate) use timer::{Timer, TimerAction};

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -44,7 +44,7 @@ pub use plugin::{
     CancelHandle, CompiledPlugin, Plugin, WasmInput, EXTISM_ENV_MODULE, EXTISM_USER_MODULE,
 };
 pub use plugin_builder::{DebugOptions, PluginBuilder};
-pub use pool::Pool;
+pub use pool::{Pool, PoolPlugin};
 
 pub(crate) use internal::{Internal, Wasi};
 pub(crate) use timer::{Timer, TimerAction};

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -191,6 +191,7 @@ pub(crate) fn profiling_strategy() -> ProfilingStrategy {
 /// Defines an input type for Wasm data.
 ///
 /// Types that implement `Into<WasmInput>` can be passed directly into `Plugin::new`
+#[derive(Clone)]
 pub enum WasmInput<'a> {
     /// Raw Wasm module
     Data(std::borrow::Cow<'a, [u8]>),

--- a/runtime/src/plugin_builder.rs
+++ b/runtime/src/plugin_builder.rs
@@ -33,6 +33,7 @@ impl Default for DebugOptions {
 }
 
 /// PluginBuilder is used to configure and create `Plugin` instances
+#[derive(Clone)]
 pub struct PluginBuilder<'a> {
     pub(crate) source: WasmInput<'a>,
     pub(crate) config: Option<wasmtime::Config>,

--- a/runtime/src/pool.rs
+++ b/runtime/src/pool.rs
@@ -61,10 +61,7 @@ impl<Key: std::fmt::Debug + Clone + std::hash::Hash + Eq> Pool<Key> {
     }
 
     /// Add a plugin using a callback function
-    pub fn add<F: Fn() -> Result<Plugin, Error>>(&self, key: Key, source: F)
-    where
-        F: 'static,
-    {
+    pub fn add<F: 'static + Fn() -> Result<Plugin, Error>>(&self, key: Key, source: F) {
         let mut pool = self.inner.lock().unwrap();
         if !pool.instances.contains_key(&key) {
             pool.instances.insert(key.clone(), vec![]);

--- a/runtime/src/pool.rs
+++ b/runtime/src/pool.rs
@@ -147,7 +147,7 @@ impl<Key: std::fmt::Debug + Clone + std::hash::Hash + Eq> Pool<Key> {
         f: impl FnOnce(&mut Plugin) -> Result<T, Error>,
     ) -> Result<Option<T>, Error> {
         if let Some(plugin) = self.get(key, timeout)? {
-            return f(&mut *plugin.plugin()).map(Some);
+            return f(&mut plugin.plugin()).map(Some);
         }
         Ok(None)
     }

--- a/runtime/src/pool.rs
+++ b/runtime/src/pool.rs
@@ -1,0 +1,117 @@
+use dashmap::DashMap;
+use extism::{FromBytesOwned, ToBytes};
+
+#[derive(Clone)]
+pub struct PoolPlugin {
+    inner: std::rc::Rc<std::cell::RefCell<extism::Plugin>>,
+}
+
+impl PoolPlugin {
+    fn new(plugin: extism::Plugin) -> Self {
+        Self {
+            inner: std::rc::Rc::new(std::cell::RefCell::new(plugin)),
+        }
+    }
+
+    pub fn plugin(&self) -> std::cell::RefMut<extism::Plugin> {
+        self.inner.borrow_mut()
+    }
+
+    pub fn call<'a, Input: ToBytes<'a>, Output: FromBytesOwned>(
+        &self,
+        name: impl AsRef<str>,
+        input: Input,
+    ) -> Result<Output, extism::Error> {
+        self.plugin().call(name.as_ref(), input)
+    }
+}
+
+type PluginSource = dyn Fn() -> Result<extism::Plugin, extism::Error>;
+
+struct PoolInner<Key: std::fmt::Debug + Clone + std::hash::Hash + Eq = String> {
+    plugins: DashMap<Key, Box<PluginSource>>,
+    instances: DashMap<Key, Vec<PoolPlugin>>,
+}
+
+#[derive(Clone)]
+pub struct Pool<Key: std::fmt::Debug + Clone + std::hash::Hash + Eq = String> {
+    max_instances: usize,
+    inner: std::sync::Arc<PoolInner<Key>>,
+}
+
+unsafe impl<T: std::fmt::Debug + Clone + std::hash::Hash + Eq> Send for Pool<T> {}
+unsafe impl<T: std::fmt::Debug + Clone + std::hash::Hash + Eq> Sync for Pool<T> {}
+
+impl<Key: std::fmt::Debug + Clone + std::hash::Hash + Eq> Pool<Key> {
+    pub fn new(max_instances: usize) -> Self {
+        Pool {
+            max_instances,
+            inner: std::sync::Arc::new(PoolInner {
+                plugins: Default::default(),
+                instances: Default::default(),
+            }),
+        }
+    }
+
+    pub fn add<F: Fn() -> Result<extism::Plugin, extism::Error>>(&self, key: Key, source: F)
+    where
+        F: 'static,
+    {
+        let pool = &self.inner;
+        if !pool.instances.contains_key(&key) {
+            pool.instances.insert(key.clone(), vec![]);
+        }
+
+        pool.plugins.insert(key, Box::new(source));
+    }
+
+    pub fn find_available(&self, key: &Key) -> Result<Option<PoolPlugin>, extism::Error> {
+        if let Some(entry) = self.inner.instances.get_mut(key) {
+            for instance in entry.iter() {
+                if std::rc::Rc::strong_count(&instance.inner) == 1 {
+                    return Ok(Some(instance.clone()));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    pub fn count(&self, key: &Key) -> usize {
+        self.inner
+            .instances
+            .get(key)
+            .map(|x| x.len())
+            .unwrap_or_default()
+    }
+
+    pub fn get(
+        &self,
+        key: &Key,
+        timeout: std::time::Duration,
+    ) -> Result<Option<PoolPlugin>, extism::Error> {
+        let start = std::time::Instant::now();
+        let max = self.max_instances;
+        if let Some(avail) = self.find_available(key)? {
+            return Ok(Some(avail));
+        }
+
+        if self.inner.instances.get(key).map(|x| x.len()).unwrap_or(0) < max {
+            if let Some(source) = self.inner.plugins.get(key) {
+                let plugin = source()?;
+                let instance = PoolPlugin::new(plugin);
+                let mut v = self.inner.instances.get_mut(key).unwrap();
+                v.push(instance);
+                return Ok(Some(v.last().unwrap().clone()));
+            }
+        }
+
+        loop {
+            if let Ok(Some(x)) = self.find_available(key) {
+                return Ok(Some(x));
+            }
+            if std::time::Instant::now() - start > timeout {
+                return Ok(None);
+            }
+        }
+    }
+}

--- a/runtime/src/pool.rs
+++ b/runtime/src/pool.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
+
 use crate::{Error, FromBytesOwned, Plugin, PluginBuilder, ToBytes};
-use dashmap::DashMap;
 
 /// `PoolPlugin` is used by the pool to track the number of live instances of a particular plugin
 #[derive(Clone, Debug)]
@@ -33,15 +34,15 @@ impl PoolPlugin {
 type PluginSource = dyn Fn() -> Result<Plugin, Error>;
 
 struct PoolInner<Key: std::fmt::Debug + Clone + std::hash::Hash + Eq = String> {
-    plugins: DashMap<Key, Box<PluginSource>>,
-    instances: DashMap<Key, Vec<PoolPlugin>>,
+    plugins: HashMap<Key, Box<PluginSource>>,
+    instances: HashMap<Key, Vec<PoolPlugin>>,
 }
 
 /// `Pool` manages threadsafe access to a limited number of instances of multiple plugins
 #[derive(Clone)]
 pub struct Pool<Key: std::fmt::Debug + Clone + std::hash::Hash + Eq = String> {
     max_instances: usize,
-    inner: std::sync::Arc<PoolInner<Key>>,
+    inner: std::sync::Arc<std::sync::Mutex<PoolInner<Key>>>,
 }
 
 unsafe impl<T: std::fmt::Debug + Clone + std::hash::Hash + Eq> Send for Pool<T> {}
@@ -52,10 +53,10 @@ impl<Key: std::fmt::Debug + Clone + std::hash::Hash + Eq> Pool<Key> {
     pub fn new(max_instances: usize) -> Self {
         Pool {
             max_instances,
-            inner: std::sync::Arc::new(PoolInner {
+            inner: std::sync::Arc::new(std::sync::Mutex::new(PoolInner {
                 plugins: Default::default(),
                 instances: Default::default(),
-            }),
+            })),
         }
     }
 
@@ -64,7 +65,7 @@ impl<Key: std::fmt::Debug + Clone + std::hash::Hash + Eq> Pool<Key> {
     where
         F: 'static,
     {
-        let pool = &self.inner;
+        let mut pool = self.inner.lock().unwrap();
         if !pool.instances.contains_key(&key) {
             pool.instances.insert(key.clone(), vec![]);
         }
@@ -74,7 +75,7 @@ impl<Key: std::fmt::Debug + Clone + std::hash::Hash + Eq> Pool<Key> {
 
     /// Add a plugin using a `PluginBuilder`
     pub fn add_builder(&self, key: Key, source: PluginBuilder<'static>) {
-        let pool = &self.inner;
+        let mut pool = self.inner.lock().unwrap();
         if !pool.instances.contains_key(&key) {
             pool.instances.insert(key.clone(), vec![]);
         }
@@ -84,7 +85,8 @@ impl<Key: std::fmt::Debug + Clone + std::hash::Hash + Eq> Pool<Key> {
     }
 
     fn find_available(&self, key: &Key) -> Result<Option<PoolPlugin>, Error> {
-        if let Some(entry) = self.inner.instances.get_mut(key) {
+        let mut pool = self.inner.lock().unwrap();
+        if let Some(entry) = pool.instances.get_mut(key) {
             for instance in entry.iter() {
                 if std::rc::Rc::strong_count(&instance.0) == 1 {
                     return Ok(Some(instance.clone()));
@@ -97,6 +99,8 @@ impl<Key: std::fmt::Debug + Clone + std::hash::Hash + Eq> Pool<Key> {
     /// Get the number of live instances for a plugin
     pub fn count(&self, key: &Key) -> usize {
         self.inner
+            .lock()
+            .unwrap()
             .instances
             .get(key)
             .map(|x| x.len())
@@ -117,13 +121,16 @@ impl<Key: std::fmt::Debug + Clone + std::hash::Hash + Eq> Pool<Key> {
             return Ok(Some(avail));
         }
 
-        if self.inner.instances.get(key).map(|x| x.len()).unwrap_or(0) < max {
-            if let Some(source) = self.inner.plugins.get(key) {
-                let plugin = source()?;
-                let instance = PoolPlugin::new(plugin);
-                let mut v = self.inner.instances.get_mut(key).unwrap();
-                v.push(instance);
-                return Ok(Some(v.last().unwrap().clone()));
+        {
+            let mut pool = self.inner.lock().unwrap();
+            if pool.instances.get(key).map(|x| x.len()).unwrap_or_default() < max {
+                if let Some(source) = pool.plugins.get(key) {
+                    let plugin = source()?;
+                    let instance = PoolPlugin::new(plugin);
+                    let v = pool.instances.get_mut(key).unwrap();
+                    v.push(instance);
+                    return Ok(Some(v.last().unwrap().clone()));
+                }
             }
         }
 

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -1,3 +1,4 @@
 mod issues;
 mod kernel;
+mod pool;
 mod runtime;

--- a/runtime/src/tests/pool.rs
+++ b/runtime/src/tests/pool.rs
@@ -1,43 +1,38 @@
-#[cfg(test)]
-mod tests {
-    use crate::*;
+use crate::*;
 
-    fn run_thread(p: Pool<String>, i: u64) -> std::thread::JoinHandle<()> {
-        let t = std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_millis(i));
-            let s: String = p
-                .get(&"test".to_string(), std::time::Duration::from_secs(5))
-                .unwrap()
-                .unwrap()
-                .call("count_vowels", "abc")
-                .unwrap();
-            println!("{}", s);
-        });
-        t
+fn run_thread(p: Pool<String>, i: u64) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(i));
+        let s: String = p
+            .get(&"test".to_string(), std::time::Duration::from_secs(5))
+            .unwrap()
+            .unwrap()
+            .call("count_vowels", "abc")
+            .unwrap();
+        println!("{}", s);
+    })
+}
+
+#[test]
+fn test_threads() {
+    let data = include_bytes!("../../../wasm/code.wasm");
+    let pool: Pool<String> = Pool::new(2);
+
+    let test = "test".to_string();
+    pool.add_builder(
+        test.clone(),
+        extism::PluginBuilder::new(extism::Manifest::new([extism::Wasm::data(data)]))
+            .with_wasi(true),
+    );
+
+    let mut threads = vec![];
+    threads.push(run_thread(pool.clone(), 1000));
+    threads.push(run_thread(pool.clone(), 1000));
+    threads.push(run_thread(pool.clone(), 500));
+    threads.push(run_thread(pool.clone(), 0));
+
+    for t in threads {
+        t.join().unwrap();
     }
-
-    #[test]
-    fn test_threads() {
-        let pool: Pool<String> = Pool::new(2);
-
-        let test = "test".to_string();
-        pool.add(test.clone(), || {
-            extism::Plugin::new(
-                extism::Manifest::new([extism::Wasm::file("../wasm/code.wasm")]),
-                vec![],
-                true,
-            )
-        });
-
-        let mut threads = vec![];
-        threads.push(run_thread(pool.clone(), 1000));
-        threads.push(run_thread(pool.clone(), 1000));
-        threads.push(run_thread(pool.clone(), 500));
-        threads.push(run_thread(pool.clone(), 0));
-
-        for t in threads {
-            t.join().unwrap();
-        }
-        assert_eq!(pool.count(&test), 2);
-    }
+    assert_eq!(pool.count(&test), 2);
 }

--- a/runtime/src/tests/pool.rs
+++ b/runtime/src/tests/pool.rs
@@ -1,0 +1,43 @@
+#[cfg(test)]
+mod tests {
+    use crate::*;
+
+    fn run_thread(p: Pool<String>, i: u64) -> std::thread::JoinHandle<()> {
+        let t = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(i));
+            let s: String = p
+                .get(&"test".to_string(), std::time::Duration::from_secs(5))
+                .unwrap()
+                .unwrap()
+                .call("count_vowels", "abc")
+                .unwrap();
+            println!("{}", s);
+        });
+        t
+    }
+
+    #[test]
+    fn test_threads() {
+        let pool: Pool<String> = Pool::new(2);
+
+        let test = "test".to_string();
+        pool.add(test.clone(), || {
+            extism::Plugin::new(
+                extism::Manifest::new([extism::Wasm::file("../wasm/code.wasm")]),
+                vec![],
+                true,
+            )
+        });
+
+        let mut threads = vec![];
+        threads.push(run_thread(pool.clone(), 1000));
+        threads.push(run_thread(pool.clone(), 1000));
+        threads.push(run_thread(pool.clone(), 500));
+        threads.push(run_thread(pool.clone(), 0));
+
+        for t in threads {
+            t.join().unwrap();
+        }
+        assert_eq!(pool.count(&test), 2);
+    }
+}

--- a/runtime/src/tests/pool.rs
+++ b/runtime/src/tests/pool.rs
@@ -4,7 +4,7 @@ fn run_thread(p: Pool<String>, i: u64) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         std::thread::sleep(std::time::Duration::from_millis(i));
         let s: String = p
-            .get(&"test".to_string(), std::time::Duration::from_secs(5))
+            .get(&"test".to_string(), std::time::Duration::from_secs(1))
             .unwrap()
             .unwrap()
             .call("count_vowels", "abc")
@@ -15,24 +15,34 @@ fn run_thread(p: Pool<String>, i: u64) -> std::thread::JoinHandle<()> {
 
 #[test]
 fn test_threads() {
-    let data = include_bytes!("../../../wasm/code.wasm");
-    let pool: Pool<String> = Pool::new(2);
+    for i in 1..=3 {
+        let data = include_bytes!("../../../wasm/code.wasm");
+        let pool: Pool<String> = Pool::new(i);
 
-    let test = "test".to_string();
-    pool.add_builder(
-        test.clone(),
-        extism::PluginBuilder::new(extism::Manifest::new([extism::Wasm::data(data)]))
-            .with_wasi(true),
-    );
+        let test = "test".to_string();
+        pool.add_builder(
+            test.clone(),
+            extism::PluginBuilder::new(extism::Manifest::new([extism::Wasm::data(data)]))
+                .with_wasi(true),
+        );
 
-    let mut threads = vec![];
-    threads.push(run_thread(pool.clone(), 1000));
-    threads.push(run_thread(pool.clone(), 1000));
-    threads.push(run_thread(pool.clone(), 500));
-    threads.push(run_thread(pool.clone(), 0));
+        let mut threads = vec![];
+        threads.push(run_thread(pool.clone(), 1000));
+        threads.push(run_thread(pool.clone(), 1000));
+        threads.push(run_thread(pool.clone(), 1000));
+        threads.push(run_thread(pool.clone(), 1000));
+        threads.push(run_thread(pool.clone(), 1000));
+        threads.push(run_thread(pool.clone(), 1000));
+        threads.push(run_thread(pool.clone(), 500));
+        threads.push(run_thread(pool.clone(), 500));
+        threads.push(run_thread(pool.clone(), 500));
+        threads.push(run_thread(pool.clone(), 500));
+        threads.push(run_thread(pool.clone(), 500));
+        threads.push(run_thread(pool.clone(), 0));
 
-    for t in threads {
-        t.join().unwrap();
+        for t in threads {
+            t.join().unwrap();
+        }
+        assert!(pool.count(&test) <= i);
     }
-    assert_eq!(pool.count(&test), 2);
 }

--- a/runtime/src/tests/pool.rs
+++ b/runtime/src/tests/pool.rs
@@ -17,7 +17,7 @@ fn run_thread(p: Pool<String>, i: u64) -> std::thread::JoinHandle<()> {
 fn test_threads() {
     for i in 1..=3 {
         let data = include_bytes!("../../../wasm/code.wasm");
-        let pool: Pool<String> = Pool::new(i);
+        let pool: Pool<String> = PoolBuilder::new().with_max_instances(i).build();
 
         let test = "test".to_string();
         pool.add_builder(


### PR DESCRIPTION
- `Pool` allows for a configurable number of instances for each plugin and will block waiting for a plugin to become available if the limit is reached