### PR TITLE
fix(libextism): namespace ExtismValType

### DIFF
--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -7,7 +7,7 @@ fn main() {
 #define EXTISM_SUCCESS 0
 
 /** An alias for I64 to signify an Extism pointer */
-#define PTR I64
+#define EXTISM_PTR ExtismValType_I64
 ";
     if let Ok(x) = cbindgen::Builder::new()
         .with_crate(".")

--- a/runtime/extism.h
+++ b/runtime/extism.h
@@ -10,7 +10,7 @@
 #define EXTISM_SUCCESS 0
 
 /** An alias for I64 to signify an Extism pointer */
-#define PTR I64
+#define EXTISM_PTR ExtismValType_I64
 
 
 /**
@@ -20,31 +20,31 @@ typedef enum {
   /**
    * Signed 32 bit integer.
    */
-  I32,
+  ExtismValType_I32,
   /**
    * Signed 64 bit integer.
    */
-  I64,
+  ExtismValType_I64,
   /**
    * Floating point 32 bit integer.
    */
-  F32,
+  ExtismValType_F32,
   /**
    * Floating point 64 bit integer.
    */
-  F64,
+  ExtismValType_F64,
   /**
    * A 128 bit number.
    */
-  V128,
+  ExtismValType_V128,
   /**
    * A reference to a Wasm function.
    */
-  FuncRef,
+  ExtismValType_FuncRef,
   /**
    * A reference to opaque data in the Wasm instance.
    */
-  ExternRef,
+  ExtismValType_ExternRef,
 } ExtismValType;
 
 /**

--- a/runtime/src/function.rs
+++ b/runtime/src/function.rs
@@ -4,6 +4,7 @@ use wasmtime::Caller;
 use crate::{error, trace, CurrentPlugin, Error};
 
 /// An enumeration of all possible value types in WebAssembly.
+/// cbindgen:prefix-with-name
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 #[repr(C)]
 pub enum ValType {


### PR DESCRIPTION
Some of the old constants conflicted with Perl headers used for build Perl extensions such the [perl-sdk](https://github.com/extism/perl-sdk/blob/002e4437ac214c927f429f7088830f79d205e949/Extism/lib/Extism/XS.xs). This fix would allow removing the copy of extism.h (inlined in that file linked) out of the perl-sdk.

These constants especially `I32` likely have conflicts with many other large C codebases.

A new extism release with this fix should not be made until the effective sdks (cpp-sdk) have an update ready.