### PR TITLE
refactor: remove HttpRequest.header alias

### DIFF
--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -10,7 +10,6 @@ pub type ManifestMemory = MemoryOptions;
 #[serde(deny_unknown_fields)]
 pub struct MemoryOptions {
     /// The max number of WebAssembly pages that should be allocated
-    #[serde(alias = "max")]
     pub max_pages: Option<u32>,
 
     /// The maximum number of bytes allowed in an HTTP response


### PR DESCRIPTION
https://github.com/extism/dotnet-pdk/pull/84 brought to my attention that the Rust SDK supports both `headers` and `header` while the go sdk only supports `headers`. After talking to Zach, we decided to remove the `header` alias from the Rust SDK too, since it's obsolete and we want people to use `headers`