### PR TITLE
refactor!: update to wasmtime 20 or greater

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-wasmtime = ">= 14.0.0, < 18.0.0"
-wasmtime-wasi = ">= 14.0.0, < 18.0.0"
+wasmtime = ">= 20.0.0, < 22.0.0"
+wasmtime-wasi = ">= 20.0.0, < 22.0.0"
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/runtime/src/internal.rs
+++ b/runtime/src/internal.rs
@@ -3,7 +3,7 @@ use crate::*;
 /// WASI context
 pub struct Wasi {
     /// wasi
-    pub ctx: wasmtime_wasi::WasiCtx,
+    pub ctx: wasmtime_wasi::preview1::WasiP1Ctx,
 }
 
 /// InternalExt provides a unified way of acessing `memory`, `store` and `internal` values

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -310,7 +310,8 @@ impl Plugin {
             .coredump_on_trap(debug_options.coredump.is_some())
             .profiler(debug_options.profiling_strategy)
             .wasm_tail_call(true)
-            .wasm_function_references(true);
+            .wasm_function_references(true)
+            .wasm_gc(true);
 
         match cache_dir {
             Some(None) => (),

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -259,12 +259,7 @@ fn relink(
         let name = f.name();
         let ns = f.namespace().unwrap_or(EXTISM_USER_MODULE);
         unsafe {
-            linker.func_new(
-                ns,
-                name,
-                f.ty(&engine).clone(),
-                &*(f.f.as_ref() as *const _),
-            )?;
+            linker.func_new(ns, name, f.ty(engine).clone(), &*(f.f.as_ref() as *const _))?;
         }
     }
 

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -224,7 +224,7 @@ fn relink(
     macro_rules! add_funcs {
             ($($name:ident($($args:expr),*) $(-> $($r:expr),*)?);* $(;)?) => {
                 $(
-                    let t = FuncType::new([$($args),*], [$($($r),*)?]);
+                    let t = FuncType::new(&engine, [$($args),*], [$($($r),*)?]);
                     linker.func_new(EXTISM_ENV_MODULE, stringify!($name), t, pdk::$name)?;
                 )*
             };
@@ -250,7 +250,7 @@ fn relink(
 
     // If wasi is enabled then add it to the linker
     if with_wasi {
-        wasmtime_wasi::add_to_linker(&mut linker, |x: &mut CurrentPlugin| {
+        wasmtime_wasi::preview1::add_to_linker_sync(&mut linker, |x: &mut CurrentPlugin| {
             &mut x.wasi.as_mut().unwrap().ctx
         })?;
     }
@@ -259,7 +259,12 @@ fn relink(
         let name = f.name();
         let ns = f.namespace().unwrap_or(EXTISM_USER_MODULE);
         unsafe {
-            linker.func_new(ns, name, f.ty().clone(), &*(f.f.as_ref() as *const _))?;
+            linker.func_new(
+                ns,
+                name,
+                f.ty(&engine).clone(),
+                &*(f.f.as_ref() as *const _),
+            )?;
         }
     }
 
@@ -465,7 +470,7 @@ impl Plugin {
                 if let Some(f) = x.func() {
                     let (params, mut results) = (f.params(), f.results());
                     match (params.len(), results.len()) {
-                        (0, 1) => results.next() == Some(wasmtime::ValType::I32),
+                        (0, 1) => matches!(results.next(), Some(wasmtime::ValType::I32)),
                         (0, 0) => true,
                         _ => false,
                     }
@@ -481,7 +486,7 @@ impl Plugin {
         &mut self,
         input: *const u8,
         mut len: usize,
-        host_context: Option<ExternRef>,
+        host_context: Option<Rooted<ExternRef>>,
     ) -> Result<(), Error> {
         self.output = Output::default();
         self.clear_error()?;
@@ -615,7 +620,7 @@ impl Plugin {
                     if let Some(reactor_init) = reactor_init {
                         reactor_init.call(&mut store, &[], &mut [])?;
                     }
-                    let mut results = vec![Val::null(); init.ty(&store).results().len()];
+                    let mut results = vec![Val::I32(0); init.ty(&store).results().len()];
                     init.call(
                         &mut store,
                         &[Val::I32(0), Val::I32(0)],
@@ -700,7 +705,7 @@ impl Plugin {
         lock: &mut std::sync::MutexGuard<Option<Instance>>,
         name: impl AsRef<str>,
         input: impl AsRef<[u8]>,
-        host_context: Option<ExternRef>,
+        host_context: Option<Rooted<ExternRef>>,
     ) -> Result<i32, (Error, i32)> {
         let name = name.as_ref();
         let input = input.as_ref();
@@ -748,7 +753,7 @@ impl Plugin {
         self.current_plugin_mut().start_time = std::time::Instant::now();
 
         // Call the function
-        let mut results = vec![wasmtime::Val::null(); n_results];
+        let mut results = vec![wasmtime::Val::I32(0); n_results];
         let mut res = func.call(self.store_mut(), &[], results.as_mut_slice());
 
         // Stop timer
@@ -833,13 +838,7 @@ impl Plugin {
                     }
                 }
 
-                let wasi_exit_code = e
-                    .downcast_ref::<wasmtime_wasi::I32Exit>()
-                    .map(|e| e.0)
-                    .or_else(|| {
-                        e.downcast_ref::<wasmtime_wasi::preview2::I32Exit>()
-                            .map(|e| e.0)
-                    });
+                let wasi_exit_code = e.downcast_ref::<wasmtime_wasi::I32Exit>().map(|e| e.0);
                 if let Some(exit_code) = wasi_exit_code {
                     debug!(
                         plugin = self.id.to_string(),
@@ -921,7 +920,8 @@ impl Plugin {
         let lock = self.instance.clone();
         let mut lock = lock.lock().unwrap();
         let data = input.to_bytes()?;
-        self.raw_call(&mut lock, name, data, Some(ExternRef::new(host_context)))
+        let ctx = ExternRef::new(&mut self.store, host_context)?;
+        self.raw_call(&mut lock, name, data, Some(ctx))
             .map_err(|e| e.0)
             .and_then(move |_| self.output())
     }


### PR DESCRIPTION
- Breaking: No longer copies Extism config values into WASI environment variables because the new interface doesn't allow for the environment to be updated - these should be accessed using the Extism config functions instead
- Requires wasmtime 20 or greater
- Enables wasm-gc
- Similar to https://github.com/extism/extism/pull/697 without sockets or additional support for command modules
