### PR TITLE
fix(libextism): improve static linking pkgconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ endif
 build:
 	cargo build --release $(FEATURE_FLAGS) --manifest-path libextism/Cargo.toml $(TARGET_FLAGS)
 	sed -e "s%@CMAKE_INSTALL_PREFIX@%$(DEST)%" libextism/extism.pc.in > libextism/extism.pc
-	sed -e "s%@CMAKE_INSTALL_PREFIX@%$(DEST)%" libextism/extism-static.pc.in > libextism/extism-static.pc
-	sed -ie "s%@Libs.private: @%Libs.private: $(PRIVATE_LIBS)% " libextism/extism-static.pc
+	sed -e "s%@CMAKE_INSTALL_PREFIX@%$(DEST)%" \
+	    -e "s%Libs: %Libs: $(PRIVATE_LIBS) %" libextism/extism-static.pc.in > libextism/extism-static.pc
 
 bench:
 	@(cargo criterion $(TARGET_FLAGS) || echo 'For nicer output use cargo-criterion: `cargo install cargo-criterion` - using `cargo bench`') && cargo bench $(TARGET_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ AEXT=a
 FEATURES?=default
 DEFAULT_FEATURES?=yes
 RUST_TARGET?=
-PRIVATE_LIBS=
+EXTRA_LIBS=
 
 UNAME := $(shell uname -s)
 ifeq ($(UNAME),Darwin)
 	SOEXT=dylib
-	PRIVATE_LIBS=-framework Security
+	EXTRA_LIBS=-framework Security
 endif
 
 ifeq ($(DEFAULT_FEATURES),no)
@@ -32,7 +32,7 @@ build:
 	cargo build --release $(FEATURE_FLAGS) --manifest-path libextism/Cargo.toml $(TARGET_FLAGS)
 	sed -e "s%@CMAKE_INSTALL_PREFIX@%$(DEST)%" libextism/extism.pc.in > libextism/extism.pc
 	sed -e "s%@CMAKE_INSTALL_PREFIX@%$(DEST)%" \
-	    -e "s%Libs: %Libs: $(PRIVATE_LIBS) %" libextism/extism-static.pc.in > libextism/extism-static.pc
+	    -e "s%Libs: %Libs: $(EXTRA_LIBS) %" libextism/extism-static.pc.in > libextism/extism-static.pc
 
 bench:
 	@(cargo criterion $(TARGET_FLAGS) || echo 'For nicer output use cargo-criterion: `cargo install cargo-criterion` - using `cargo bench`') && cargo bench $(TARGET_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,12 @@ AEXT=a
 FEATURES?=default
 DEFAULT_FEATURES?=yes
 RUST_TARGET?=
+PRIVATE_LIBS=
 
 UNAME := $(shell uname -s)
 ifeq ($(UNAME),Darwin)
 	SOEXT=dylib
+	PRIVATE_LIBS=-framework Security
 endif
 
 ifeq ($(DEFAULT_FEATURES),no)
@@ -30,6 +32,7 @@ build:
 	cargo build --release $(FEATURE_FLAGS) --manifest-path libextism/Cargo.toml $(TARGET_FLAGS)
 	sed -e "s%@CMAKE_INSTALL_PREFIX@%$(DEST)%" libextism/extism.pc.in > libextism/extism.pc
 	sed -e "s%@CMAKE_INSTALL_PREFIX@%$(DEST)%" libextism/extism-static.pc.in > libextism/extism-static.pc
+	sed -ie "s%@Libs.private: @%Libs.private: $(PRIVATE_LIBS)% " libextism/extism-static.pc
 
 bench:
 	@(cargo criterion $(TARGET_FLAGS) || echo 'For nicer output use cargo-criterion: `cargo install cargo-criterion` - using `cargo bench`') && cargo bench $(TARGET_FLAGS)

--- a/libextism/Makefile
+++ b/libextism/Makefile
@@ -4,7 +4,7 @@ build:
 
 .PHONY: static
 static:
-	$(CC) -g -o example example.c -l:libextism.a -lm
+	$(CC) -g -o example example.c -l:libextism.a -lm -lpthread
 
 # if needed, set PKG_CONFIG_PATH= to the directory with extism*.pc installed
 LDFLAGS=`pkg-config --libs extism`

--- a/libextism/example.c
+++ b/libextism/example.c
@@ -9,7 +9,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-void log_handler(const char *line, uintptr_t length) {
+void log_handler(const char *line, ExtismSize length) {
   fwrite(line, length, 1, stderr);
 }
 

--- a/libextism/extism-static.pc.in
+++ b/libextism/extism-static.pc.in
@@ -5,6 +5,6 @@ includedir=${prefix}/include
 Version: 1.0.0
 Name: Extism
 Description: The framework for building with WebAssembly (wasm).
-Libs: -L${libdir} -l:libextism.a
-Libs.private: -lm
+Libs: ${libdir}/libextism.a
+Libs.private: -lm -lpthread
 Cflags: -I${includedir}

--- a/libextism/extism.pc.in
+++ b/libextism/extism.pc.in
@@ -6,5 +6,5 @@ Version: 1.0.0
 Name: Extism
 Description: The framework for building with WebAssembly (wasm).
 Libs: -L${libdir} -lextism
-Libs.private: -lm
+Libs.private: -lm -lpthread
 Cflags: -I${includedir}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1"
 toml = "0.8"
 sha2 = "0.10"
 tracing = "0.1"
-tracing-subscriber = {version = "0.3", features = ["std", "env-filter", "fmt"]}
+tracing-subscriber = {version = "0.3.18", features = ["std", "env-filter", "fmt"]}
 url = "2"
 glob = "0.3"
 ureq = {version = "2.5", optional=true}


### PR DESCRIPTION
This includes two fixes:

* link static library by absolute path (should fix static linking on Mac/ with `lld`)
* link `libpthread` , this should be a no-op on systems with modern libc, but should fix static linking on systems with glibc pre 2.34 see https://developers.redhat.com/articles/2021/12/17/why-glibc-234-removed-libpthread and error http://www.cpantesters.org/cpan/report/669fdfc8-25a4-11ef-9502-51fb6d8775ea

@zshipko if you could verify `make pkg-config-static` and the resulting `example` executable in `libextism` works on Mac that would be greatly appreciated.