### PR TITLE
fix: require error messages to be null terminated in C SDK

### DIFF
--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -81,6 +81,8 @@ pub struct Plugin {
     pub(crate) store_needs_reset: bool,
 
     pub(crate) debug_options: DebugOptions,
+
+    pub(crate) error_msg: Option<Vec<u8>>,
 }
 
 unsafe impl Send for Plugin {}
@@ -361,6 +363,7 @@ impl Plugin {
             store_needs_reset: false,
             debug_options,
             _functions: imports,
+            error_msg: None,
         };
 
         plugin.current_plugin_mut().store = &mut plugin.store;


### PR DESCRIPTION
Related to https://github.com/extism/python-sdk/issues/23 - there is currently no way to get the length of the error message, so we need to make sure it is a valid C string.