### PR TITLE
feat(runtime): add log level set/get for pdk control

### DIFF
--- a/runtime/extism.h
+++ b/runtime/extism.h
@@ -313,5 +313,5 @@ bool extism_plugin_reset(ExtismPlugin *plugin);
 const char *extism_version(void);
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2,7 +2,6 @@
 extern crate self as extism;
 
 pub(crate) use extism_convert::*;
-use pdk::{log_level_to_int, GLOBAL_LOG_LEVEL};
 pub(crate) use std::collections::BTreeMap;
 use std::str::FromStr;
 pub(crate) use wasmtime::*;
@@ -79,18 +78,16 @@ pub fn set_log_callback<F: 'static + Clone + Fn(&str)>(
     filter: impl AsRef<str>,
 ) -> Result<(), Error> {
     let filter = filter.as_ref();
-    let is_level = tracing::Level::from_str(filter);
-    if let Ok(level) = is_level {
-        GLOBAL_LOG_LEVEL.store(
-            log_level_to_int(level),
-            std::sync::atomic::Ordering::Relaxed,
-        );
-    }
-    let cfg = tracing_subscriber::FmtSubscriber::builder().with_env_filter(
-        tracing_subscriber::EnvFilter::builder()
-            .with_default_directive(tracing::Level::ERROR.into())
-            .parse_lossy(filter),
-    );
+    let is_level = tracing::Level::from_str(filter).is_ok();
+    let cfg = tracing_subscriber::FmtSubscriber::builder().with_env_filter({
+        let x = tracing_subscriber::EnvFilter::builder()
+            .with_default_directive(tracing::Level::ERROR.into());
+        if is_level {
+            x.parse_lossy(format!("extism={}", filter))
+        } else {
+            x.parse_lossy(filter)
+        }
+    });
     let w = LogFunction { func };
     cfg.with_ansi(false)
         .with_writer(move || w.clone())

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate self as extism;
 
 pub(crate) use extism_convert::*;
+use pdk::{log_level_to_int, GLOBAL_LOG_LEVEL};
 pub(crate) use std::collections::BTreeMap;
 use std::str::FromStr;
 pub(crate) use wasmtime::*;
@@ -78,6 +79,13 @@ pub fn set_log_callback<F: 'static + Clone + Fn(&str)>(
     filter: impl AsRef<str>,
 ) -> Result<(), Error> {
     let filter = filter.as_ref();
+    let is_level = tracing::Level::from_str(filter);
+    if let Ok(level) = is_level {
+        GLOBAL_LOG_LEVEL.store(
+            log_level_to_int(level),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
     let cfg = tracing_subscriber::FmtSubscriber::builder().with_env_filter(
         tracing_subscriber::EnvFilter::builder()
             .with_default_directive(tracing::Level::ERROR.into())

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -249,6 +249,7 @@ fn relink(
         log_debug(I64);
         log_error(I64);
         log_trace(I64);
+        get_log_level() -> I32;
     );
 
     let mut linked = BTreeSet::new();


### PR DESCRIPTION
In addition to this change, @zshipko is looking into if we need to extract basic log level info from the more complex `filter` string, and how to require `tracing` compatibility to at least set some level (or to work when there is no level set thus ignoring all logs)

For other runtimes, there is still an equivalent implementation for `get_log_level() -> I32`  in Go and JS, as well as the ability to set the log level for the host, which is then loaded when `get_log_level` is called. 

TODO:
- [ ] Go SDK implementation
- [ ] JS SDK implementation