### PR TITLE
fix: avoid creating too many externrefs

### DIFF
--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -202,7 +202,7 @@ impl CurrentPlugin {
             .data_mut(&mut *store)?
             .downcast_mut::<Box<dyn std::any::Any + Send + Sync>>()
         {
-            Some(xs) => match (&mut *xs).downcast_mut::<T>() {
+            Some(xs) => match xs.downcast_mut::<T>() {
                 Some(xs) => Ok(xs),
                 None => anyhow::bail!("could not downcast extism_context inner value"),
             },

--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -204,7 +204,7 @@ impl CurrentPlugin {
         {
             Some(xs) => match (&mut *xs).downcast_mut::<T>() {
                 Some(xs) => Ok(xs),
-                None => anyhow::bail!("could not downcast extism_context 1"),
+                None => anyhow::bail!("could not downcast extism_context inner value"),
             },
             None => anyhow::bail!("could not downcast extism_context"),
         }

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -218,6 +218,7 @@ fn add_module<T: 'static>(
     Ok(())
 }
 
+#[allow(clippy::type_complexity)]
 fn relink(
     engine: &Engine,
     mut store: &mut Store<CurrentPlugin>,
@@ -292,7 +293,7 @@ fn relink(
     }
 
     let inner: Box<dyn std::any::Any + Send + Sync> = Box::new(());
-    let host_context = ExternRef::new(&mut store, inner)?;
+    let host_context = ExternRef::new(store, inner)?;
 
     let main = &modules[MAIN_KEY];
     let instance_pre = linker.instantiate_pre(main)?;
@@ -768,7 +769,7 @@ impl Plugin {
                 let x: Box<T> = Box::new(host_context);
                 *inner = x;
             }
-            Some(self.host_context.clone())
+            Some(self.host_context)
         } else {
             None
         };

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -334,8 +334,10 @@ fn test_multiple_instantiations() {
 #[test]
 fn test_globals() {
     let mut plugin = Plugin::new(WASM_GLOBALS, [], true).unwrap();
-    for i in 0..100000 {
-        let Json(count) = plugin.call::<_, Json<Count>>("globals", "").unwrap();
+    for i in 0..100001 {
+        let Json(count) = plugin
+            .call_with_host_context::<_, Json<Count>, _>("globals", "", ())
+            .unwrap();
         assert_eq!(count.count, i);
     }
 }
@@ -366,7 +368,7 @@ fn test_call_with_host_context() {
         [PTR],
         UserData::default(),
         |current_plugin, _val, ret, _user_data: UserData<()>| {
-            let foo = current_plugin.host_context::<Foo>()?;
+            let foo = current_plugin.host_context::<Foo>()?.clone();
             let hnd = current_plugin.memory_new(foo.message)?;
             ret[0] = current_plugin.memory_to_val(hnd);
             Ok(())


### PR DESCRIPTION
Updates plugins to allocate a single `ExternRef` for the host context up front, to avoid running into the `failed to allocate externref` error from Wasmtime