### PR TITLE
feat: add ability to configure static memory size

### DIFF
--- a/runtime/examples/readme.rs
+++ b/runtime/examples/readme.rs
@@ -30,6 +30,7 @@ fn main() {
     );
     let manifest = Manifest::new([url]);
     let mut plugin = PluginBuilder::new(manifest)
+        .with_static_memory_size(1024 * 1024 * 50)
         .with_wasi(true)
         .with_function(
             "kv_read",

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -317,6 +317,7 @@ impl Plugin {
             Default::default(),
             None,
             None,
+            None,
         )
     }
 
@@ -327,6 +328,7 @@ impl Plugin {
         debug_options: DebugOptions,
         cache_dir: Option<Option<PathBuf>>,
         fuel: Option<u64>,
+        static_memory_size: Option<u64>,
     ) -> Result<Plugin, Error> {
         // Setup wasmtime types
         let mut config = Config::new();
@@ -338,6 +340,10 @@ impl Plugin {
             .wasm_tail_call(true)
             .wasm_function_references(true)
             .wasm_gc(true);
+
+        if let Some(x) = static_memory_size {
+            config.static_memory_maximum_size(x);
+        }
 
         if fuel.is_some() {
             config.consume_fuel(true);

--- a/runtime/src/plugin_builder.rs
+++ b/runtime/src/plugin_builder.rs
@@ -40,6 +40,7 @@ pub struct PluginBuilder<'a> {
     debug_options: DebugOptions,
     cache_config: Option<Option<PathBuf>>,
     fuel: Option<u64>,
+    static_memory_size: Option<u64>,
 }
 
 impl<'a> PluginBuilder<'a> {
@@ -52,6 +53,7 @@ impl<'a> PluginBuilder<'a> {
             debug_options: DebugOptions::default(),
             cache_config: None,
             fuel: None,
+            static_memory_size: None,
         }
     }
 
@@ -150,9 +152,16 @@ impl<'a> PluginBuilder<'a> {
         self
     }
 
-    // Limit the number of instructions that can be executed
+    /// Limit the number of instructions that can be executed
     pub fn with_fuel_limit(mut self, fuel: u64) -> Self {
         self.fuel = Some(fuel);
+        self
+    }
+
+    /// Limit the size of the memory allocated up-front when
+    /// instantiating a module
+    pub fn with_static_memory_size(mut self, size: u64) -> Self {
+        self.static_memory_size = Some(size);
         self
     }
 
@@ -165,6 +174,7 @@ impl<'a> PluginBuilder<'a> {
             self.debug_options,
             self.cache_config,
             self.fuel,
+            self.static_memory_size,
         )
     }
 }

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -401,6 +401,7 @@ pub unsafe extern "C" fn extism_plugin_new_with_fuel_limit(
         Default::default(),
         None,
         Some(fuel_limit),
+        Some(1024 * 1024 * 1024 * 2),
     );
 
     match plugin {


### PR DESCRIPTION
This makes it possible to configure the amount of memory that's allocated up front when instantiating a plugin.