### PR TITLE
feat: add `PluginBuilder::with_wasmtime_config`

### DIFF
--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -331,8 +331,9 @@ impl Plugin {
         config: Option<Config>,
     ) -> Result<Plugin, Error> {
         // Setup wasmtime types
-        let mut config = config.unwrap_or_else(|| Config::new());
+        let mut config = config.unwrap_or_else(Config::new);
         config
+            .async_support(false)
             .epoch_interruption(true)
             .debug_info(debug_options.debug_info)
             .coredump_on_trap(debug_options.coredump.is_some())

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -331,7 +331,7 @@ impl Plugin {
         config: Option<Config>,
     ) -> Result<Plugin, Error> {
         // Setup wasmtime types
-        let mut config = config.unwrap_or_else(Config::new);
+        let mut config = config.unwrap_or_default();
         config
             .async_support(false)
             .epoch_interruption(true)

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -317,6 +317,7 @@ impl Plugin {
             Default::default(),
             None,
             None,
+            None,
         )
     }
 
@@ -327,9 +328,10 @@ impl Plugin {
         debug_options: DebugOptions,
         cache_dir: Option<Option<PathBuf>>,
         fuel: Option<u64>,
+        config: Option<Config>,
     ) -> Result<Plugin, Error> {
         // Setup wasmtime types
-        let mut config = Config::new();
+        let mut config = config.unwrap_or_else(|| Config::new());
         config
             .epoch_interruption(true)
             .debug_info(debug_options.debug_info)

--- a/runtime/src/plugin_builder.rs
+++ b/runtime/src/plugin_builder.rs
@@ -40,6 +40,7 @@ pub struct PluginBuilder<'a> {
     debug_options: DebugOptions,
     cache_config: Option<Option<PathBuf>>,
     fuel: Option<u64>,
+    config: Option<wasmtime::Config>,
 }
 
 impl<'a> PluginBuilder<'a> {
@@ -52,6 +53,7 @@ impl<'a> PluginBuilder<'a> {
             debug_options: DebugOptions::default(),
             cache_config: None,
             fuel: None,
+            config: None,
         }
     }
 
@@ -150,9 +152,15 @@ impl<'a> PluginBuilder<'a> {
         self
     }
 
-    // Limit the number of instructions that can be executed
+    /// Limit the number of instructions that can be executed
     pub fn with_fuel_limit(mut self, fuel: u64) -> Self {
         self.fuel = Some(fuel);
+        self
+    }
+
+    /// Configure an initial wasmtime config to be passed to the plugin
+    pub fn with_wasmtime_config(mut self, config: wasmtime::Config) -> Self {
+        self.config = Some(config);
         self
     }
 
@@ -165,6 +173,7 @@ impl<'a> PluginBuilder<'a> {
             self.debug_options,
             self.cache_config,
             self.fuel,
+            self.config,
         )
     }
 }

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -401,6 +401,7 @@ pub unsafe extern "C" fn extism_plugin_new_with_fuel_limit(
         Default::default(),
         None,
         Some(fuel_limit),
+        None,
     );
 
     match plugin {


### PR DESCRIPTION
An alternative to #763, this PR allows an initial `wasmtime::Config` to be passed in when building a plugin. Some of these values may be overwritten by the Extism runtime, but it allows for things like static memory size and other low-level details to be handled directly instead of us having to wrap every option ourselves.