### PR TITLE
cleanup!: add `extism_manifest::LocalPath` for specifying allowed paths

### DIFF
--- a/manifest/src/lib.rs
+++ b/manifest/src/lib.rs
@@ -1,6 +1,10 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+mod local_path;
+
+pub use local_path::LocalPath;
+
 #[deprecated]
 pub type ManifestMemory = MemoryOptions;
 
@@ -279,7 +283,7 @@ pub struct Manifest {
     /// the path on disk to the path it should be available inside the plugin.
     /// For example, `".": "/tmp"` would mount the current directory as `/tmp` inside the module
     #[serde(default)]
-    pub allowed_paths: Option<BTreeMap<String, PathBuf>>,
+    pub allowed_paths: Option<BTreeMap<LocalPath, PathBuf>>,
 
     /// The plugin timeout in milliseconds
     #[serde(default)]
@@ -337,15 +341,15 @@ impl Manifest {
     }
 
     /// Add a path to `allowed_paths`
-    pub fn with_allowed_path(mut self, src: String, dest: impl AsRef<Path>) -> Self {
+    pub fn with_allowed_path(mut self, src: impl Into<LocalPath>, dest: impl AsRef<Path>) -> Self {
         let dest = dest.as_ref().to_path_buf();
         match &mut self.allowed_paths {
             Some(p) => {
-                p.insert(src, dest);
+                p.insert(src.into(), dest);
             }
             None => {
                 let mut p = BTreeMap::new();
-                p.insert(src, dest);
+                p.insert(src.into(), dest);
                 self.allowed_paths = Some(p);
             }
         }
@@ -354,7 +358,7 @@ impl Manifest {
     }
 
     /// Set `allowed_paths`
-    pub fn with_allowed_paths(mut self, paths: impl Iterator<Item = (String, PathBuf)>) -> Self {
+    pub fn with_allowed_paths(mut self, paths: impl Iterator<Item = (LocalPath, PathBuf)>) -> Self {
         self.allowed_paths = Some(paths.collect());
         self
     }

--- a/manifest/src/local_path.rs
+++ b/manifest/src/local_path.rs
@@ -1,0 +1,119 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LocalPath {
+    ReadOnly(PathBuf),
+    ReadWrite(PathBuf),
+}
+
+impl LocalPath {
+    pub fn as_path(&self) -> &Path {
+        match self {
+            LocalPath::ReadOnly(p) => p.as_path(),
+            LocalPath::ReadWrite(p) => p.as_path(),
+        }
+    }
+}
+
+impl From<&str> for LocalPath {
+    fn from(value: &str) -> Self {
+        if value.starts_with("ro:") {
+            let s = &value[3..];
+            LocalPath::ReadOnly(PathBuf::from(s))
+        } else {
+            LocalPath::ReadWrite(PathBuf::from(value))
+        }
+    }
+}
+
+impl From<String> for LocalPath {
+    fn from(value: String) -> Self {
+        LocalPath::from(value.as_str())
+    }
+}
+
+impl From<PathBuf> for LocalPath {
+    fn from(value: PathBuf) -> Self {
+        LocalPath::ReadWrite(value)
+    }
+}
+
+impl From<&Path> for LocalPath {
+    fn from(value: &Path) -> Self {
+        LocalPath::ReadWrite(value.to_path_buf())
+    }
+}
+
+impl serde::Serialize for LocalPath {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            LocalPath::ReadOnly(path) => {
+                let s = match path.to_str() {
+                    Some(s) => s,
+                    None => {
+                        return Err(serde::ser::Error::custom(
+                            "Path contains invalid UTF-8 characters",
+                        ))
+                    }
+                };
+
+                format!("ro:{s}").serialize(serializer)
+            }
+            LocalPath::ReadWrite(path) => path.serialize(serializer),
+        }
+    }
+}
+
+struct LocalPathVisitor;
+
+impl<'de> serde::de::Visitor<'de> for LocalPathVisitor {
+    type Value = LocalPath;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("path string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(From::from(v))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(From::from(v))
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        std::str::from_utf8(v)
+            .map(From::from)
+            .map_err(|_| serde::de::Error::invalid_value(serde::de::Unexpected::Bytes(v), &self))
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        String::from_utf8(v).map(From::from).map_err(|e| {
+            serde::de::Error::invalid_value(serde::de::Unexpected::Bytes(&e.into_bytes()), &self)
+        })
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for LocalPath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        deserializer.deserialize_string(LocalPathVisitor)
+    }
+}

--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -344,9 +344,9 @@ impl CurrentPlugin {
 
             if let Some(a) = &manifest.allowed_paths {
                 for (k, v) in a.iter() {
-                    let readonly = k.starts_with("ro:");
+                    let readonly = matches!(k, extism_manifest::LocalPath::ReadOnly(_));
 
-                    let dir_path = if readonly { &k[3..] } else { k };
+                    let dir_path = k.as_path();
 
                     let dir = wasi_common::sync::dir::Dir::from_cap_std(
                         wasi_common::sync::Dir::open_ambient_dir(dir_path, auth)?,


### PR DESCRIPTION
Provides a higher-level API for specifying allowed paths