### PR TITLE
Fix: no method named `free` found for mutable reference `&mut current_plugin::CurrentPlugin` in the current scope

### DIFF
--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -183,7 +183,7 @@ pub(crate) fn http_request(
             Some(h) => h,
             None => anyhow::bail!("http_request input is invalid: {http_req_offset}"),
         };
-        data.free(handle)?;
+        data.memory_free(handle)?;
         let req: extism_manifest::HttpRequest = serde_json::from_slice(data.memory_bytes(handle)?)?;
         output[0] = Val::I64(0);
         anyhow::bail!(


### PR DESCRIPTION
think there's a typo for this block when the `http` feature is disabled