### PR TITLE
Change `function_exists` to `&self`

### DIFF
--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -530,7 +530,7 @@ impl Plugin {
     }
 
     /// Returns `true` if the given function exists, otherwise `false`
-    pub fn function_exists(&mut self, function: impl AsRef<str>) -> bool {
+    pub fn function_exists(&self, function: impl AsRef<str>) -> bool {
         self.modules[MAIN_KEY]
             .get_export(function.as_ref())
             .map(|x| {


### PR DESCRIPTION
I wrap the `Plugin` instance in a `RwLock` and because `function_exists` requires `&mut self`, I have to acquire a write lock everytime to just check if a function exists, which causes lock contention.

This changes it to `&self` since it doesn't need to mutate.