### PR TITLE
Trigger NuGet package publishing when a new release is published

### DIFF
--- a/.github/workflows/release-dotnet-native.yaml
+++ b/.github/workflows/release-dotnet-native.yaml
@@ -1,4 +1,6 @@
 on:
+  release:
+    types: [published, edited]
   workflow_dispatch:
 
 name: Release .NET Native NuGet Packages


### PR DESCRIPTION
This makes sure the latest releases are always available on NuGet too