### PR TITLE
fix: improve sdk error messages around imports

### DIFF
--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -298,33 +298,6 @@ fn relink(
     let mut linker = Linker::new(engine);
     linker.allow_shadowing(true);
 
-    for (name, module) in modules.iter() {
-        if name == EXTISM_ENV_MODULE {
-            continue;
-        }
-
-        for import in module.imports() {
-            if import.module() == EXTISM_ENV_MODULE
-                && modules[EXTISM_ENV_MODULE]
-                    .get_export(import.name())
-                    .is_none()
-            {
-                let (kind, ty) = match import.ty() {
-                    ExternType::Func(t) => ("function", t.to_string()),
-                    ExternType::Global(t) => ("global", t.content().to_string()),
-                    ExternType::Table(t) => ("table", t.element().to_string()),
-                    ExternType::Memory(_) => ("memory", String::new()),
-                };
-                anyhow::bail!(
-                    "Invalid {kind} import from extism:host/env: {} {ty}\n\n\
-                    Note: This may indicate that the PDK that was used to build this plugin has additional features that aren't \
-                    available in this version of the SDK, try updating the SDK to the latest version.",
-                    import.name(),
-                )
-            }
-        }
-    }
-
     // Define PDK functions
     macro_rules! add_funcs {
             ($($name:ident($($args:expr),*) $(-> $($r:expr),*)?);* $(;)?) => {
@@ -351,6 +324,36 @@ fn relink(
         log_trace(I64);
         get_log_level() -> I32;
     );
+
+    for (name, module) in modules.iter() {
+        if name == EXTISM_ENV_MODULE {
+            continue;
+        }
+
+        for import in module.imports() {
+            if import.module() == EXTISM_ENV_MODULE
+                && modules[EXTISM_ENV_MODULE]
+                    .get_export(import.name())
+                    .is_none()
+                && linker
+                    .get(&mut store, EXTISM_ENV_MODULE, import.name())
+                    .is_none()
+            {
+                let (kind, ty) = match import.ty() {
+                    ExternType::Func(t) => ("function", t.to_string()),
+                    ExternType::Global(t) => ("global", t.content().to_string()),
+                    ExternType::Table(t) => ("table", t.element().to_string()),
+                    ExternType::Memory(_) => ("memory", String::new()),
+                };
+                anyhow::bail!(
+                    "Invalid {kind} import from extism:host/env: {} {ty}\n\n\
+                    Note: This may indicate that the PDK that was used to build this plugin has additional features that aren't \
+                    available in this version of the SDK, try updating the SDK to the latest version.",
+                    import.name(),
+                )
+            }
+        }
+    }
 
     let mut linked = BTreeSet::new();
     linker.module(&mut store, EXTISM_ENV_MODULE, &modules[EXTISM_ENV_MODULE])?;

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -305,9 +305,9 @@ fn relink(
 
         for import in module.imports() {
             if import.module() == EXTISM_ENV_MODULE
-                && !modules[EXTISM_ENV_MODULE]
+                && modules[EXTISM_ENV_MODULE]
                     .get_export(import.name())
-                    .is_some()
+                    .is_none()
             {
                 let (kind, ty) = match import.ty() {
                     ExternType::Func(t) => ("function", t.to_string()),

--- a/runtime/src/sdk.rs
+++ b/runtime/src/sdk.rs
@@ -352,8 +352,11 @@ pub unsafe extern "C" fn extism_compiled_plugin_new(
         .map(|v| Box::into_raw(Box::new(v)))
         .unwrap_or_else(|e| {
             if !errmsg.is_null() {
-                let e = std::ffi::CString::new(format!("Unable to compile Extism plugin: {}", e))
-                    .unwrap();
+                let e = std::ffi::CString::new(format!(
+                    "Unable to compile Extism plugin: {}",
+                    e.root_cause(),
+                ))
+                .unwrap();
                 *errmsg = e.into_raw();
             }
             std::ptr::null_mut()
@@ -426,8 +429,11 @@ pub unsafe extern "C" fn extism_plugin_new(
         .map(|v| Box::into_raw(Box::new(v)))
         .unwrap_or_else(|e| {
             if !errmsg.is_null() {
-                let e = std::ffi::CString::new(format!("Unable to compile Extism plugin: {}", e))
-                    .unwrap();
+                let e = std::ffi::CString::new(format!(
+                    "Unable to compile Extism plugin: {}",
+                    e.root_cause(),
+                ))
+                .unwrap();
                 *errmsg = e.into_raw();
             }
             std::ptr::null_mut()
@@ -444,8 +450,11 @@ pub unsafe extern "C" fn extism_plugin_new_from_compiled(
     match plugin {
         Err(e) => {
             if !errmsg.is_null() {
-                let e = std::ffi::CString::new(format!("Unable to create Extism plugin: {}", e))
-                    .unwrap();
+                let e = std::ffi::CString::new(format!(
+                    "Unable to create Extism plugin: {}",
+                    e.root_cause(),
+                ))
+                .unwrap();
                 *errmsg = e.into_raw();
             }
             std::ptr::null_mut()
@@ -512,8 +521,11 @@ pub unsafe extern "C" fn extism_plugin_new_with_fuel_limit(
         Ok(x) => x,
         Err(e) => {
             if !errmsg.is_null() {
-                let e = std::ffi::CString::new(format!("Unable to compile Extism plugin: {}", e))
-                    .unwrap();
+                let e = std::ffi::CString::new(format!(
+                    "Unable to compile Extism plugin: {}",
+                    e.root_cause(),
+                ))
+                .unwrap();
                 *errmsg = e.into_raw();
             }
             return std::ptr::null_mut();
@@ -525,8 +537,11 @@ pub unsafe extern "C" fn extism_plugin_new_with_fuel_limit(
     match plugin {
         Err(e) => {
             if !errmsg.is_null() {
-                let e = std::ffi::CString::new(format!("Unable to create Extism plugin: {}", e))
-                    .unwrap();
+                let e = std::ffi::CString::new(format!(
+                    "Unable to create Extism plugin: {}",
+                    e.root_cause(),
+                ))
+                .unwrap();
                 *errmsg = e.into_raw();
             }
             std::ptr::null_mut()


### PR DESCRIPTION
Closes https://github.com/extism/extism/issues/801


Updates the error from:

```
Unable to compile Extism plugin: incompatible import type for `extism:host/user::wrong_type`
```

to:

```
Unable to compile Extism plugin: types incompatible: expected type `(func (result i32))`, found type `(func (result i64))`
```