### PR TITLE
feat: added a function to track fuel consumption

### DIFF
--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -455,7 +455,6 @@ impl Plugin {
             _functions: imports,
             error_msg: None,
             fuel: compiled.options.fuel,
-            remaining_fuel: None,
             host_context,
         };
 

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -147,6 +147,7 @@ pub struct Plugin {
     pub(crate) error_msg: Option<Vec<u8>>,
 
     pub(crate) fuel: Option<u64>,
+    pub(crate) remaining_fuel: Option<u64>,
 
     pub(crate) host_context: Rooted<ExternRef>,
 }
@@ -455,6 +456,7 @@ impl Plugin {
             _functions: imports,
             error_msg: None,
             fuel: compiled.options.fuel,
+            remaining_fuel: None,
             host_context,
         };
 
@@ -919,6 +921,11 @@ impl Plugin {
         let _ = self.timer_tx.send(TimerAction::Stop { id: self.id });
         self.store_needs_reset = name == "_start";
 
+        // Get remaining fuel
+        if let Some(fuel) = self.store.get_fuel().ok() {
+            self.remaining_fuel = Some(fuel);
+        }
+
         let mut rc = -1;
         if self.store.get_fuel().is_ok_and(|x| x == 0) {
             res = Err(Error::msg("plugin ran out of fuel"));
@@ -1153,6 +1160,23 @@ impl Plugin {
             Ok(())
         } else {
             anyhow::bail!("Plugin::clear_error failed, extism:host/env::error_set not found")
+        }
+    }
+
+    /// Returns the amount of fuel consumed by the plugin.
+    ///
+    /// This function calculates the difference between the initial fuel and the remaining fuel.
+    /// If either the initial fuel or the remaining fuel is not set, it returns `None`.
+    ///
+    /// # Returns
+    ///
+    /// * `Some(u64)` - The amount of fuel consumed.
+    /// * `None` - If the initial fuel or remaining fuel is not set.
+    pub fn fuel_consumed(&self) -> Option<u64> {
+        if let (Some(initial), Some(remaining)) = (self.fuel, self.remaining_fuel) {
+            Some(initial.saturating_sub(remaining))
+        } else {
+            None
         }
     }
 }

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -922,7 +922,7 @@ impl Plugin {
         self.store_needs_reset = name == "_start";
 
         // Get remaining fuel
-        if let Some(fuel) = self.store.get_fuel().ok() {
+        if let Ok(fuel) = self.store.get_fuel() {
             self.remaining_fuel = Some(fuel);
         }
 

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -841,4 +841,3 @@ fn test_http_response_headers_disabled() {
     println!("{:?}", res);
     assert!(res.is_empty());
 }
-

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -259,6 +259,23 @@ fn test_fuel() {
 }
 
 #[test]
+fn test_fuel_consumption() {
+    let manifest = Manifest::new([extism_manifest::Wasm::data(WASM_LOOP)]);
+    let mut plugin = PluginBuilder::new(manifest)
+        .with_wasi(true)
+        .with_fuel_limit(10000)
+        .build()
+        .unwrap();
+
+    let output: Result<&[u8], Error> = plugin.call("loop_forever", "abc123");
+    assert!(output.is_err());
+
+    let fuel_consumed = plugin.fuel_consumed().unwrap();
+    println!("Fuel consumed: {}", fuel_consumed);
+    assert!(fuel_consumed > 0);
+}
+
+#[test]
 #[cfg(feature = "http")]
 fn test_http_timeout() {
     let f = Function::new(
@@ -824,3 +841,4 @@ fn test_http_response_headers_disabled() {
     println!("{:?}", res);
     assert!(res.is_empty());
 }
+


### PR DESCRIPTION
This PR adds a function to get the fuel consumed by a plugin. This is useful for systems that want to fairly balance compute. It's my first time doing anything in rust so let me know if something needs improvements!