### PR TITLE
cleanup: stop timer from using 100% cpu when no timeouts are set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,14 @@ jobs:
           sccache: 'true'
           manylinux: 2_28
 
+      - name: Install libunwind
+        if: ${{ matrix.target == 'x86_64-linux-android' }}
+        run: sudo apt install android-libunwind-dev
+
+      - name: Install libunwind
+        if: ${{ matrix.target == 'aarch64-linux-android' }}
+        run: sudo apt install android-libunwind-dev
+
       - name: Add pkg-config files except on MSVC
         if: ${{ matrix.target != 'x86_64-pc-windows-msvc' }}
         shell: bash

--- a/runtime/src/timer.rs
+++ b/runtime/src/timer.rs
@@ -124,10 +124,8 @@ impl Timer {
                     if let Ok(x) = rx.recv_timeout(timeout) {
                         handle!(x)
                     }
-                } else {
-                    if let Ok(x) = rx.recv() {
-                        handle!(x)
-                    }
+                } else if let Ok(x) = rx.recv() {
+                    handle!(x)
                 }
             }
         });

--- a/runtime/src/timer.rs
+++ b/runtime/src/timer.rs
@@ -98,30 +98,27 @@ impl Timer {
 
                 let mut timeout: Option<std::time::Duration> = None;
 
-                plugins = plugins
-                    .into_iter()
-                    .filter(|(_k, (engine, end))| {
-                        if let Some(end) = end {
-                            let now = std::time::Instant::now();
-                            if end <= &now {
-                                engine.increment_epoch();
-                                return false;
-                            } else {
-                                let time_left = (*end - now)
-                                    .saturating_sub(std::time::Duration::from_millis(1));
-                                if let Some(t) = &timeout {
-                                    if time_left < *t {
-                                        timeout = Some(time_left);
-                                    }
-                                } else {
+                plugins.retain(|_k, (engine, end)| {
+                    if let Some(end) = end {
+                        let now = std::time::Instant::now();
+                        if *end <= now {
+                            engine.increment_epoch();
+                            return false;
+                        } else {
+                            let time_left =
+                                (*end - now).saturating_sub(std::time::Duration::from_millis(1));
+                            if let Some(t) = &timeout {
+                                if time_left < *t {
                                     timeout = Some(time_left);
                                 }
+                            } else {
+                                timeout = Some(time_left);
                             }
                         }
+                    }
 
-                        true
-                    })
-                    .collect();
+                    true
+                });
 
                 if let Some(timeout) = timeout {
                     if let Ok(x) = rx.recv_timeout(timeout) {


### PR DESCRIPTION
Fixes an issue reported on discord (https://discord.com/channels/1011124058408112148/1154513155209298041/1329622656235864156) where the timer thread is taking up an entire CPU