### PR TITLE
chore: update wasmtime bounds to include more versions

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,9 +9,9 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-wasmtime = {version = ">= 26.0.0, < 27.0.0"}
-wasi-common = {version = ">= 26.0.0, < 27.0.0"}
-wiggle = {version = ">= 26.0.0, < 27.0.0"}
+wasmtime = {version = ">= 27.0.0, < 30.0.0"}
+wasi-common = {version = ">= 27.0.0, < 30.0.0"}
+wiggle = {version = ">= 27.0.0, < 30.0.0"}
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"

--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -206,15 +206,16 @@ impl CurrentPlugin {
             anyhow::bail!("expected extism_context to be an externref value",)
         };
 
-        match xs
-            .data_mut(&mut *store)?
-            .downcast_mut::<Box<dyn std::any::Any + Send + Sync>>()
-        {
-            Some(xs) => match xs.downcast_mut::<T>() {
-                Some(xs) => Ok(xs),
-                None => anyhow::bail!("could not downcast extism_context inner value"),
-            },
-            None => anyhow::bail!("could not downcast extism_context"),
+        if let Some(d) = xs.data_mut(&mut *store)? {
+            match d.downcast_mut::<Box<dyn std::any::Any + Send + Sync>>() {
+                Some(xs) => match xs.downcast_mut::<T>() {
+                    Some(xs) => Ok(xs),
+                    None => anyhow::bail!("could not downcast extism_context inner value"),
+                },
+                None => anyhow::bail!("could not downcast extism_context"),
+            }
+        } else {
+            anyhow::bail!("extism_context not found")
         }
     }
 


### PR DESCRIPTION
Upgrades from wasmtime 26 to wasmtime 27-29, allowing us to support more versions (including the possibility of supporting future releases without changes)