### PR TITLE
chore: include wasmtime 30 in supported bounds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,33 +9,17 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      # This is the name of your group, it will be used in PR titles and branch names
+      wasmtime-deps:
+        # A pattern can be...
+        patterns:
+          - "wasmtime"
+          - "wasi-common"
+          - "wiggle"
 
   - package-ecosystem: "pip"
     directory: "python"
     schedule:
       interval: "weekly"
 
-  - package-ecosystem: "mix"
-    directory: "elixir"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "node"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "bundler"
-    directory: "ruby"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,9 +9,9 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-wasmtime = {version = ">= 27.0.0, < 30.0.0"}
-wasi-common = {version = ">= 27.0.0, < 30.0.0"}
-wiggle = {version = ">= 27.0.0, < 30.0.0"}
+wasmtime = {version = ">= 27.0.0, < 31.0.0"}
+wasi-common = {version = ">= 27.0.0, < 31.0.0"}
+wiggle = {version = ">= 27.0.0, < 31.0.0"}
 anyhow = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"


### PR DESCRIPTION
Also updates dependabot config to bundle wasmtime updates so this can be done automatically in the future.