### PR TITLE
fix: use gh release download instead of downloading from github action artifacts in dotnet workflow

### DIFF
--- a/.github/workflows/release-dotnet-native.yaml
+++ b/.github/workflows/release-dotnet-native.yaml
@@ -20,10 +20,13 @@ jobs:
         uses: actions/setup-dotnet@v3.0.3
         with:
            dotnet-version: 7.x
-      - uses: dawidd6/action-download-artifact@v6
-        with:
-          workflow: release.yml
-          name: release-artifacts
+      - name: download release
+        run: |
+          tag='${{ github.ref }}'
+          tag="${tag/refs\/tags\//}"
+          gh release download "$tag" -p 'libextism-*.tar.gz'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract Archive
         run: |      
           extract_archive() {


### PR DESCRIPTION
It seems like at some point we changed the `release.yml` workflow to create multiple artifacts instead of one `release-artifacts` tarball. I changed the .NET Nuget workflow to be more like Python