### PR TITLE
Disable unused wasmtime features

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,19 +9,40 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-wasmtime = {version = ">= 27.0.0, < 31.0.0"}
-wasi-common = {version = ">= 27.0.0, < 31.0.0"}
-wiggle = {version = ">= 27.0.0, < 31.0.0"}
+wasmtime = { version = ">= 27.0.0, < 31.0.0", default-features = false, features = [
+  'cache',
+  'gc',
+  'gc-drc',
+  'gc-null',
+  'wat',
+  'profiling',
+  'parallel-compilation',
+  'cranelift',
+  'pooling-allocator',
+  'demangle',
+  'addr2line',
+  'coredump',
+  'debug-builtins',
+  'runtime',
+  'threads',
+  'std',
+] }
+wasi-common = { version = ">= 27.0.0, < 31.0.0" }
+wiggle = { version = ">= 27.0.0, < 31.0.0" }
 anyhow = "1"
-serde = {version = "1", features = ["derive"]}
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 sha2 = "0.10"
 tracing = "0.1"
-tracing-subscriber = {version = "0.3.18", features = ["std", "env-filter", "fmt"]}
+tracing-subscriber = { version = "0.3.18", features = [
+  "std",
+  "env-filter",
+  "fmt",
+] }
 url = "2"
 glob = "0.3"
-ureq = {version = "3.0", optional=true}
+ureq = { version = "3.0", optional = true }
 extism-manifest = { workspace = true }
 extism-convert = { workspace = true, features = ["extism-path"] }
 uuid = { version = "1", features = ["v4"] }
@@ -29,9 +50,9 @@ libc = "0.2"
 
 [features]
 default = ["http", "register-http", "register-filesystem"]
-register-http = ["ureq"] # enables wasm to be downloaded using http
-register-filesystem = [] # enables wasm to be loaded from disk
-http = ["ureq"]          # enables extism_http_request
+register-http = ["ureq"]                                   # enables wasm to be downloaded using http
+register-filesystem = []                                   # enables wasm to be loaded from disk
+http = ["ureq"]                                            # enables extism_http_request
 
 [build-dependencies]
 cbindgen = { version = "0.29", default-features = false }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,6 +16,9 @@ wasmtime = { version = ">= 27.0.0, < 31.0.0", default-features = false, features
   'cranelift',
   'coredump',
   'wat',
+  'parallel-compilation',
+  'pooling-allocator',
+  'demangle',
 ] }
 wasi-common = { version = ">= 27.0.0, < 31.0.0" }
 wiggle = { version = ">= 27.0.0, < 31.0.0" }
@@ -44,19 +47,7 @@ register-http = ["ureq"]                                   # enables wasm to be 
 register-filesystem = []                                   # enables wasm to be loaded from disk
 http = ["ureq"]                                            # enables extism_http_request
 wasmtime-default-features = [
-  "wasmtime/async",
-  "wasmtime/pooling-allocator",
-  'wasmtime/gc-null',
-  'wasmtime/profiling',
-  'wasmtime/parallel-compilation',
-  'wasmtime/pooling-allocator',
-  'wasmtime/demangle',
-  'wasmtime/addr2line',
-  'wasmtime/debug-builtins',
-  'wasmtime/runtime',
-  'wasmtime/component-model',
-  'wasmtime/threads',
-  'wasmtime/std',
+  'wasmtime/default',
 ]
 
 [build-dependencies]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -15,6 +15,7 @@ wasmtime = { version = ">= 27.0.0, < 31.0.0", default-features = false, features
   'gc-drc',
   'cranelift',
   'coredump',
+  'wat',
 ] }
 wasi-common = { version = ">= 27.0.0, < 31.0.0" }
 wiggle = { version = ">= 27.0.0, < 31.0.0" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 wasmtime = { version = ">= 27.0.0, < 31.0.0", default-features = false, features = [
   'cache',
   'gc',
+  'gc-drc',
   'cranelift',
   'coredump',
 ] }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,12 +16,6 @@ wasmtime = { version = ">= 27.0.0, < 31.0.0", default-features = false, features
   'cranelift',
   'coredump',
   'wat',
-  'pooling-allocator',
-  'demangle',
-  'addr2line',
-  'coredump',
-  'parallel-compilation',
-  'profiling'
 ] }
 wasi-common = { version = ">= 27.0.0, < 31.0.0" }
 wiggle = { version = ">= 27.0.0, < 31.0.0" }
@@ -45,10 +39,25 @@ uuid = { version = "1", features = ["v4"] }
 libc = "0.2"
 
 [features]
-default = ["http", "register-http", "register-filesystem"]
+default = ["http", "register-http", "register-filesystem", "wasmtime-default-features"]
 register-http = ["ureq"]                                   # enables wasm to be downloaded using http
 register-filesystem = []                                   # enables wasm to be loaded from disk
 http = ["ureq"]                                            # enables extism_http_request
+wasmtime-default-features = [
+  "wasmtime/async",
+  "wasmtime/pooling-allocator",
+  'wasmtime/gc-null',
+  'wasmtime/profiling',
+  'wasmtime/parallel-compilation',
+  'wasmtime/pooling-allocator',
+  'wasmtime/demangle',
+  'wasmtime/addr2line',
+  'wasmtime/debug-builtins',
+  'wasmtime/runtime',
+  'wasmtime/component-model',
+  'wasmtime/threads',
+  'wasmtime/std',
+]
 
 [build-dependencies]
 cbindgen = { version = "0.29", default-features = false }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,6 +16,12 @@ wasmtime = { version = ">= 27.0.0, < 31.0.0", default-features = false, features
   'cranelift',
   'coredump',
   'wat',
+  'pooling-allocator',
+  'demangle',
+  'addr2line',
+  'coredump',
+  'parallel-compilation',
+  'profiling'
 ] }
 wasi-common = { version = ">= 27.0.0, < 31.0.0" }
 wiggle = { version = ">= 27.0.0, < 31.0.0" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,20 +12,8 @@ version.workspace = true
 wasmtime = { version = ">= 27.0.0, < 31.0.0", default-features = false, features = [
   'cache',
   'gc',
-  'gc-drc',
-  'gc-null',
-  'wat',
-  'profiling',
-  'parallel-compilation',
   'cranelift',
-  'pooling-allocator',
-  'demangle',
-  'addr2line',
   'coredump',
-  'debug-builtins',
-  'runtime',
-  'threads',
-  'std',
 ] }
 wasi-common = { version = ">= 27.0.0, < 31.0.0" }
 wiggle = { version = ">= 27.0.0, < 31.0.0" }


### PR DESCRIPTION
This PR disables all possible dependencies for wasmtime, while the code can still compile. Its possible that some of these removed features should be enabled again if they help with debugging or improve performance. [Here](https://github.com/bytecodealliance/wasmtime/blob/v31.0.0/crates/wasmtime/Cargo.toml#L129) you can see all the default features, as well as documentation for each feature flag. 

It reduces the number of dependencies from 401 to 366. I didnt check the compile time but it should also be faster.

