### PR TITLE
Remove key param for PluginPool

### DIFF
--- a/runtime/src/pool.rs
+++ b/runtime/src/pool.rs
@@ -72,6 +72,9 @@ struct PoolInner {
     instances: Vec<PoolPlugin>,
 }
 
+unsafe impl Send for PoolInner {}
+unsafe impl Sync for PoolInner {}
+
 /// `Pool` manages threadsafe access to a limited number of instances of multiple plugins
 #[derive(Clone)]
 pub struct Pool {

--- a/runtime/src/tests/pool.rs
+++ b/runtime/src/tests/pool.rs
@@ -24,23 +24,25 @@ fn test_threads() {
             .with_max_instances(i)
             .build(move || plugin_builder.clone().build());
 
-        let mut threads = vec![];
-        threads.push(run_thread(pool.clone(), 1000));
-        threads.push(run_thread(pool.clone(), 1000));
-        threads.push(run_thread(pool.clone(), 1000));
-        threads.push(run_thread(pool.clone(), 1000));
-        threads.push(run_thread(pool.clone(), 1000));
-        threads.push(run_thread(pool.clone(), 1000));
-        threads.push(run_thread(pool.clone(), 500));
-        threads.push(run_thread(pool.clone(), 500));
-        threads.push(run_thread(pool.clone(), 500));
-        threads.push(run_thread(pool.clone(), 500));
-        threads.push(run_thread(pool.clone(), 500));
-        threads.push(run_thread(pool.clone(), 0));
+        let threads = vec![
+            run_thread(pool.clone(), 1000),
+            run_thread(pool.clone(), 1000),
+            run_thread(pool.clone(), 1000),
+            run_thread(pool.clone(), 1000),
+            run_thread(pool.clone(), 1000),
+            run_thread(pool.clone(), 1000),
+            run_thread(pool.clone(), 500),
+            run_thread(pool.clone(), 500),
+            run_thread(pool.clone(), 500),
+            run_thread(pool.clone(), 500),
+            run_thread(pool.clone(), 500),
+            run_thread(pool.clone(), 0),
+        ];
 
         for t in threads {
             t.join().unwrap();
         }
+
         assert!(pool.count() <= i);
     }
 }


### PR DESCRIPTION
As mentioned in https://github.com/extism/extism/pull/696/files#r1993086470, the key parameter doesnt seem very useful. You can achieve the same effect by doing `HashMap<Key, PluginPool>` in the client code. 