### PR TITLE
fix: set ureq http_status_as_error to false to allow access to headers/body of non-200 responses

### DIFF
--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -258,12 +258,16 @@ pub(crate) fn http_request(
             };
             let buf: &[u8] = data.memory_bytes(handle)?;
             let agent = ureq::agent();
-            let config = agent.configure_request(r.body(buf)?);
+            let config = agent
+                .configure_request(r.body(buf)?)
+                .http_status_as_error(false);
             let req = config.timeout_global(timeout).build();
             ureq::run(req)
         } else {
             let agent = ureq::agent();
-            let config = agent.configure_request(r.body(())?);
+            let config = agent
+                .configure_request(r.body(())?)
+                .http_status_as_error(false);
             let req = config.timeout_global(timeout).build();
             ureq::run(req)
         };


### PR DESCRIPTION
Fixes #872 