### PR TITLE
[WIP] new: Support structured tracing logs.

### DIFF
--- a/convert/src/lib.rs
+++ b/convert/src/lib.rs
@@ -11,10 +11,10 @@ extern crate self as extism_convert;
 pub use anyhow::Error;
 
 mod encoding;
-
 mod from_bytes;
 mod memory_handle;
 mod to_bytes;
+mod tracing_log;
 
 pub use encoding::{Base64, Json};
 
@@ -33,6 +33,7 @@ pub use encoding::Raw;
 pub use from_bytes::{FromBytes, FromBytesOwned};
 pub use memory_handle::MemoryHandle;
 pub use to_bytes::ToBytes;
+pub use tracing_log::TracingLog;
 
 #[cfg(test)]
 mod tests;

--- a/convert/src/tracing_log.rs
+++ b/convert/src/tracing_log.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct TracingLog {
+    /// Additional data to be rendered as fields.
+    /// https://docs.rs/tracing/latest/tracing/#recording-fields
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub fields: HashMap<String, String>,
+
+    /// The log message.
+    pub message: String,
+
+    /// The target/model the log comes from.
+    /// https://docs.rs/tracing/latest/tracing/#configuring-attributes
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1"
 toml = "0.9"
 sha2 = "0.10"
 tracing = "0.1"
+tracing_dynamic = "0.3"
 tracing-subscriber = { version = "0.3.18", features = [
   "std",
   "env-filter",
@@ -42,13 +43,16 @@ uuid = { version = "1", features = ["v4"] }
 libc = "0.2"
 
 [features]
-default = ["http", "register-http", "register-filesystem", "wasmtime-default-features"]
-register-http = ["ureq"]                                   # enables wasm to be downloaded using http
-register-filesystem = []                                   # enables wasm to be loaded from disk
-http = ["ureq"]                                            # enables extism_http_request
-wasmtime-default-features = [
-  'wasmtime/default',
+default = [
+  "http",
+  "register-http",
+  "register-filesystem",
+  "wasmtime-default-features",
 ]
+register-http = ["ureq"] # enables wasm to be downloaded using http
+register-filesystem = [] # enables wasm to be loaded from disk
+http = ["ureq"] # enables extism_http_request
+wasmtime-default-features = ['wasmtime/default']
 
 [build-dependencies]
 cbindgen = { version = "0.29", default-features = false }

--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -1,5 +1,6 @@
 /// All the functions in the file are exposed from inside WASM plugins
 use crate::*;
+use extism_convert::TracingLog;
 
 /// This macro unwraps input arguments to prevent functions from panicking,
 /// it should be used instead of `Val::unwrap_*` functions
@@ -387,24 +388,45 @@ pub fn log(
     let buf = data.memory_str(handle);
 
     match buf {
-        Ok(buf) => match level {
-            tracing::Level::ERROR => {
-                tracing::error!(plugin = id, "{}", buf)
+        Ok(buf) => {
+            use tracing_dynamic::EventFactory;
+
+            let log = if buf.starts_with('{') {
+                serde_json::from_str(buf)?
+            } else {
+                TracingLog {
+                    message: buf.to_owned(),
+                    ..Default::default()
+                }
+            };
+
+            let field_keys = log
+                .fields
+                .keys()
+                .map(|key| key.as_str())
+                .collect::<Vec<_>>();
+
+            let event_factory = EventFactory::new(
+                &id,
+                log.target.as_deref().unwrap_or_else(|| module_path!()),
+                level,
+                None,
+                None,
+                None,
+                &field_keys,
+            );
+
+            let mut event = event_factory.create();
+            event.with("plugin", &id);
+            event.with("message", &log.message);
+
+            for (key, value) in &log.fields {
+                event.with(key, value);
             }
-            tracing::Level::DEBUG => {
-                tracing::debug!(plugin = id, "{}", buf)
-            }
-            tracing::Level::WARN => {
-                tracing::warn!(plugin = id, "{}", buf)
-            }
-            tracing::Level::INFO => {
-                tracing::info!(plugin = id, "{}", buf)
-            }
-            tracing::Level::TRACE => {
-                tracing::trace!(plugin = id, "{}", buf)
-            }
-        },
-        Err(_) => tracing::error!(plugin = id, "unable to log message: {:?}", buf),
+
+            event.build();
+        }
+        Err(error) => tracing::error!(plugin = id, "unable to log message: {error:?}"),
     }
 
     data.memory_free(handle)?;


### PR DESCRIPTION
Extism has logging/tracing support currently through explicit macro usage, but what it doesn't support is inheriting `tracing` logs that come from 3rd-party crates. Right now all those messages are lost, which is a huge bummer.

I wanted to figure it if inheriting these 3rd-party logs is even possible... and it is! Turns out you can set `tracing::set_global_default` in WASM to read these logs, and then pipe them to extism. Here's an example I've been experimenting with: https://github.com/moonrepo/proto/blob/master/crates/warpgate-pdk/src/tracing.rs#L98

While this works, there is a major downside, and that is that field information is lost. Extism only supports the message string, so to pipe field data through, you need to include it in the message. This results in ugly logs, as seen here (notice the `extism::pdk` lines):

<img width="1512" height="855" alt="Screenshot 2025-07-16 at 3 00 27 PM" src="https://github.com/user-attachments/assets/b61b48ce-d278-4540-9f6f-2ec3570c1b26" />
<img width="1512" height="855" alt="Screenshot 2025-07-16 at 2 42 41 PM" src="https://github.com/user-attachments/assets/dd034b82-74d4-483c-bc46-6f8417c93b8f" />

## Solution

So in this PR, I wanted to figure out a way to support this field data, and a custom target (to override `extism::pdk`). I'm doing this by introducing a new struct, `TracingLog`, that includes this information. I've stored this struct in `extism-convert` so that it can also be used in the PDK (there will be a sibling PR to this one).

I then use the `tracing-dynamic` crate (https://github.com/BrynCooke/tracing-dynamic) to send the event, because it's currently impossible to set dynamic fields on an event (why tracing why???).