### PR TITLE
Update to wasmtime version with exceptions support

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-wasmtime = { version = ">= 27.0.0, < 31.0.0", default-features = false, features = [
+wasmtime = { version="37", default-features = false, features = [
   'cache',
   'gc',
   'gc-drc',
@@ -20,8 +20,8 @@ wasmtime = { version = ">= 27.0.0, < 31.0.0", default-features = false, features
   'pooling-allocator',
   'demangle',
 ] }
-wasi-common = { version = ">= 27.0.0, < 31.0.0" }
-wiggle = { version = ">= 27.0.0, < 31.0.0" }
+wasi-common = "37"
+wiggle = "37"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -43,12 +43,14 @@ libc = "0.2"
 
 [features]
 default = ["http", "register-http", "register-filesystem", "wasmtime-default-features"]
-register-http = ["ureq"]                                   # enables wasm to be downloaded using http
-register-filesystem = []                                   # enables wasm to be loaded from disk
-http = ["ureq"]                                            # enables extism_http_request
+register-http = ["ureq"]           # enables wasm to be downloaded using http
+register-filesystem = []           # enables wasm to be loaded from disk
+http = ["ureq"]                    # enables extism_http_request
+wasmtime-exceptions = []           # enables exception-handling proposal in wasmtime (requires wasmtime gc feature)
 wasmtime-default-features = [
   'wasmtime/default',
 ]
+
 
 [build-dependencies]
 cbindgen = { version = "0.29", default-features = false }

--- a/runtime/src/pool.rs
+++ b/runtime/src/pool.rs
@@ -49,7 +49,7 @@ impl PoolPlugin {
     }
 
     /// Access the underlying plugin
-    pub fn plugin(&self) -> std::cell::RefMut<Plugin> {
+    pub fn plugin(&self) -> std::cell::RefMut<'_, Plugin> {
         self.0.borrow_mut()
     }
 


### PR DESCRIPTION
The [wasmtime v37 release](https://github.com/bytecodealliance/wasmtime/releases/tag/v37.0.0) "now fully implements the WebAssembly exception-handling proposal." Support for exception-handling is disabled by default, but will be made default in the future (according to the release notes).

To use this new wasmtime feature, we do two things at a high level:

1. Update wasmtime dependency to version 37
2. Add a "wasmtime-exceptions" Extism feature, disabled by default.

Updating to the new wasmtime dependency required some semantical changes to how the cache is configured.

There is also a new `ExternType` to match on when handling invalid imports.

My use case for this feature is being able to execute Lua code from Extism. In actuality, I'm running a Rust plugin, which is using [mlua](https://github.com/mlua-rs/mlua) to execute the Lua. I have it working locally with this change. Fwiw, mlua recently added [support to compile to wasi](https://github.com/mlua-rs/mlua/issues/366), which should make this all work end-to-end with no special patches if we can get this merged.

This is my first time working on the Extism codebase, so please let me know if I missed anything.