### PR TITLE
Fix pool thread safety issues (option 2)

### DIFF
--- a/convert-macros/tests/ui/invalid-encoding.stderr
+++ b/convert-macros/tests/ui/invalid-encoding.stderr
@@ -1,6 +1,7 @@
 error: encoding needs to be specified
 
          = try: `#[encoding(Json)]`
+
  --> tests/ui/invalid-encoding.rs:3:10
   |
 3 | #[derive(ToBytes)]
@@ -12,6 +13,7 @@ error: expected attribute arguments in parentheses: #[encoding(...)]
 
          = note: expects a path
          = try: `#[encoding(Json)]`
+
  --> tests/ui/invalid-encoding.rs:7:3
   |
 7 | #[encoding]
@@ -21,6 +23,7 @@ error: expected parentheses: #[encoding(...)]
 
          = note: expects a path
          = try: `#[encoding(Json)]`
+
   --> tests/ui/invalid-encoding.rs:11:12
    |
 11 | #[encoding = "string"]
@@ -30,6 +33,7 @@ error: unexpected token
 
          = note: expects a path
          = try: `#[encoding(Json)]`
+
   --> tests/ui/invalid-encoding.rs:15:21
    |
 15 | #[encoding(something, else)]
@@ -38,6 +42,7 @@ error: unexpected token
 error: only one encoding can be specified
 
          = try: remove `#[encoding(Encodings)]`
+
   --> tests/ui/invalid-encoding.rs:20:1
    |
 20 | #[encoding(Encodings)]

--- a/runtime/src/function.rs
+++ b/runtime/src/function.rs
@@ -80,7 +80,7 @@ pub(crate) enum UserDataHandle {
     #[allow(dead_code)]
     C(Arc<CPtr>),
     #[allow(dead_code)]
-    Rust(Arc<std::sync::Mutex<dyn std::any::Any>>),
+    Rust(Arc<std::sync::Mutex<dyn std::any::Any + Send>>),
 }
 
 /// UserData is used to store additional data that gets passed into host function callbacks
@@ -94,7 +94,7 @@ pub enum UserData<T: Sized> {
     Rust(Arc<std::sync::Mutex<T>>),
 }
 
-impl<T: Default> Default for UserData<T> {
+impl<T: Default + Send> Default for UserData<T> {
     fn default() -> Self {
         UserData::new(T::default())
     }
@@ -133,7 +133,10 @@ impl<T> UserData<T> {
     /// Create a new `UserData` from a Rust value
     ///
     /// This will wrap the provided value in a reference-counted mutex
-    pub fn new(x: T) -> Self {
+    pub fn new(x: T) -> Self
+    where
+        T: Send,
+    {
         let data = Arc::new(std::sync::Mutex::new(x));
         UserData::Rust(data)
     }
@@ -158,8 +161,8 @@ impl Drop for CPtr {
     }
 }
 
-unsafe impl<T> Send for UserData<T> {}
-unsafe impl<T> Sync for UserData<T> {}
+unsafe impl<T: Send> Send for UserData<T> {}
+unsafe impl<T: Send> Sync for UserData<T> {}
 unsafe impl Send for CPtr {}
 unsafe impl Sync for CPtr {}
 
@@ -188,7 +191,7 @@ pub struct Function {
 
 impl Function {
     /// Create a new host function
-    pub fn new<T: 'static, F>(
+    pub fn new<T: 'static + Send, F>(
         name: impl Into<String>,
         params: impl IntoIterator<Item = ValType>,
         results: impl IntoIterator<Item = ValType>,

--- a/runtime/src/function.rs
+++ b/runtime/src/function.rs
@@ -80,8 +80,11 @@ pub(crate) enum UserDataHandle {
     #[allow(dead_code)]
     C(Arc<CPtr>),
     #[allow(dead_code)]
-    Rust(Arc<std::sync::Mutex<dyn std::any::Any + Send>>),
+    Rust(Arc<std::sync::Mutex<dyn std::any::Any>>),
 }
+
+unsafe impl Send for UserDataHandle {}
+unsafe impl Sync for UserDataHandle {}
 
 /// UserData is used to store additional data that gets passed into host function callbacks
 ///
@@ -94,7 +97,7 @@ pub enum UserData<T: Sized> {
     Rust(Arc<std::sync::Mutex<T>>),
 }
 
-impl<T: Default + Send> Default for UserData<T> {
+impl<T: Default> Default for UserData<T> {
     fn default() -> Self {
         UserData::new(T::default())
     }
@@ -133,10 +136,7 @@ impl<T> UserData<T> {
     /// Create a new `UserData` from a Rust value
     ///
     /// This will wrap the provided value in a reference-counted mutex
-    pub fn new(x: T) -> Self
-    where
-        T: Send,
-    {
+    pub fn new(x: T) -> Self {
         let data = Arc::new(std::sync::Mutex::new(x));
         UserData::Rust(data)
     }
@@ -161,8 +161,8 @@ impl Drop for CPtr {
     }
 }
 
-unsafe impl<T: Send> Send for UserData<T> {}
-unsafe impl<T: Send> Sync for UserData<T> {}
+unsafe impl<T> Send for UserData<T> {}
+unsafe impl<T> Sync for UserData<T> {}
 unsafe impl Send for CPtr {}
 unsafe impl Sync for CPtr {}
 
@@ -191,7 +191,7 @@ pub struct Function {
 
 impl Function {
     /// Create a new host function
-    pub fn new<T: 'static + Send, F>(
+    pub fn new<T: 'static, F>(
         name: impl Into<String>,
         params: impl IntoIterator<Item = ValType>,
         results: impl IntoIterator<Item = ValType>,

--- a/runtime/src/plugin_builder.rs
+++ b/runtime/src/plugin_builder.rs
@@ -74,7 +74,7 @@ impl<'a> PluginBuilder<'a> {
     }
 
     /// Add a single host function
-    pub fn with_function<T: 'static + Send, F>(
+    pub fn with_function<T: 'static, F>(
         mut self,
         name: impl Into<String>,
         args: impl IntoIterator<Item = ValType>,
@@ -95,7 +95,7 @@ impl<'a> PluginBuilder<'a> {
     }
 
     /// Add a single host function in a specific namespace
-    pub fn with_function_in_namespace<T: 'static + Send, F>(
+    pub fn with_function_in_namespace<T: 'static, F>(
         mut self,
         namespace: impl Into<String>,
         name: impl Into<String>,

--- a/runtime/src/plugin_builder.rs
+++ b/runtime/src/plugin_builder.rs
@@ -74,7 +74,7 @@ impl<'a> PluginBuilder<'a> {
     }
 
     /// Add a single host function
-    pub fn with_function<T: 'static, F>(
+    pub fn with_function<T: 'static + Send, F>(
         mut self,
         name: impl Into<String>,
         args: impl IntoIterator<Item = ValType>,
@@ -95,7 +95,7 @@ impl<'a> PluginBuilder<'a> {
     }
 
     /// Add a single host function in a specific namespace
-    pub fn with_function_in_namespace<T: 'static, F>(
+    pub fn with_function_in_namespace<T: 'static + Send, F>(
         mut self,
         namespace: impl Into<String>,
         name: impl Into<String>,

--- a/runtime/src/pool.rs
+++ b/runtime/src/pool.rs
@@ -99,10 +99,11 @@ impl Pool {
     pub fn get(&self, timeout: std::time::Duration) -> Result<Option<PoolPlugin>, Error> {
         let start = std::time::Instant::now();
 
+        // Hold lock throughout except when waiting on condition variable
         let mut inner = self.inner.lock().unwrap();
 
         loop {
-            // Try to get an available plugin
+            // Try to pop an available plugin from the queue
             if let Some(plugin) = inner.available.pop_front() {
                 return Ok(Some(PoolPlugin {
                     plugin: Some(plugin),
@@ -111,7 +112,7 @@ impl Pool {
                 }));
             }
 
-            // Try to create a new plugin if under max
+            // Create new plugin if under capacity
             if inner.current_size < inner.max_size {
                 let plugin = (*inner.plugin_source)()?;
                 inner.current_size += 1;
@@ -122,13 +123,14 @@ impl Pool {
                 }));
             }
 
-            // Check timeout
+            // All plugins busy and at capacity. Check if we should keep waiting.
             let elapsed = std::time::Instant::now() - start;
             if elapsed >= timeout {
                 return Ok(None);
             }
 
-            // Wait for a plugin to be returned
+            // Wait for a plugin to be returned. wait_timeout releases the lock while
+            // waiting and re-acquires it when woken. Loop back to check availability.
             let remaining = timeout - elapsed;
             let (guard, wait_result) = self.cond.wait_timeout(inner, remaining).unwrap();
             inner = guard;

--- a/runtime/src/pool.rs
+++ b/runtime/src/pool.rs
@@ -1,13 +1,15 @@
 use crate::{Error, FromBytesOwned, Plugin, ToBytes};
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::sync::RwLock;
 
-// `PoolBuilder` is used to configure and create `Pool`s
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{Arc, Condvar, Mutex, RwLock, Weak},
+};
+
+/// `PoolBuilder` is used to configure and create `Pool`s
 #[derive(Debug, Clone)]
 pub struct PoolBuilder {
-    /// Max number of concurrent instances for a plugin - by default this is set to
-    /// the output of `std::thread::available_parallelism`
+    /// Max number of concurrent instances for a plugin - by default this is set to the output of
+    /// `std::thread::available_parallelism`
     pub max_instances: usize,
 }
 
@@ -24,7 +26,10 @@ impl PoolBuilder {
     }
 
     /// Create a new `Pool` with the given configuration
-    pub fn build<F: 'static + Fn() -> Result<Plugin, Error>>(self, source: F) -> Pool {
+    pub fn build<F: 'static + Fn() -> Result<Plugin, Error> + Send + Sync>(
+        self,
+        source: F,
+    ) -> Pool {
         Pool::new_from_builder(source, self)
     }
 }
@@ -39,90 +44,53 @@ impl Default for PoolBuilder {
     }
 }
 
-/// `PoolPlugin` is used by the pool to track the number of live instances of a particular plugin
-#[derive(Clone, Debug)]
-pub struct PoolPlugin(std::rc::Rc<std::cell::RefCell<Plugin>>);
-
-impl PoolPlugin {
-    fn new(plugin: Plugin) -> Self {
-        Self(std::rc::Rc::new(std::cell::RefCell::new(plugin)))
-    }
-
-    /// Access the underlying plugin
-    pub fn plugin(&self) -> std::cell::RefMut<'_, Plugin> {
-        self.0.borrow_mut()
-    }
-
-    /// Helper to call a plugin function on the underlying plugin
-    pub fn call<'a, Input: ToBytes<'a>, Output: FromBytesOwned>(
-        &self,
-        name: impl AsRef<str>,
-        input: Input,
-    ) -> Result<Output, Error> {
-        self.plugin().call(name.as_ref(), input)
-    }
-
-    /// Helper to get the underlying plugin's ID
-    pub fn id(&self) -> uuid::Uuid {
-        self.plugin().id
-    }
-}
-
-type PluginSource = dyn Fn() -> Result<Plugin, Error>;
+type PluginSource = dyn Fn() -> Result<Plugin, Error> + Send + Sync;
 
 struct PoolInner {
     plugin_source: Box<PluginSource>,
-    instances: Vec<PoolPlugin>,
+    /// Available plugins ready to be checked out
+    available: VecDeque<Plugin>,
+    /// Current number of plugins (checked out + available)
+    current_size: usize,
+    /// Maximum number of plugins
+    max_size: usize,
 }
-
-unsafe impl Send for PoolInner {}
-unsafe impl Sync for PoolInner {}
 
 /// `Pool` manages threadsafe access to a limited number of instances of multiple plugins
 #[derive(Clone)]
 pub struct Pool {
-    config: PoolBuilder,
-    inner: Arc<std::sync::Mutex<PoolInner>>,
+    inner: Arc<Mutex<PoolInner>>,
+    cond: Arc<Condvar>,
     existing_functions: Arc<RwLock<HashMap<String, bool>>>,
 }
 
-unsafe impl Send for Pool {}
-unsafe impl Sync for Pool {}
-
 impl Pool {
     /// Create a new pool with the default configuration
-    pub fn new<F: 'static + Fn() -> Result<Plugin, Error>>(source: F) -> Self {
-        Self::new_from_builder(Box::new(source), PoolBuilder::default())
+    pub fn new<F: 'static + Fn() -> Result<Plugin, Error> + Send + Sync>(source: F) -> Self {
+        Self::new_from_builder(source, PoolBuilder::default())
     }
 
     /// Create a new pool configured using a `PoolBuilder`
-    pub fn new_from_builder<F: 'static + Fn() -> Result<Plugin, Error>>(
+    pub fn new_from_builder<F: 'static + Fn() -> Result<Plugin, Error> + Send + Sync>(
         source: F,
         builder: PoolBuilder,
     ) -> Self {
+        let cond = Arc::new(Condvar::new());
         Pool {
-            config: builder,
-            inner: Arc::new(std::sync::Mutex::new(PoolInner {
+            inner: Arc::new(Mutex::new(PoolInner {
                 plugin_source: Box::new(source),
-                instances: Default::default(),
+                available: VecDeque::new(),
+                current_size: 0,
+                max_size: builder.max_instances,
             })),
-            existing_functions: RwLock::new(HashMap::default()).into(),
+            cond,
+            existing_functions: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
-    fn find_available(&self) -> Result<Option<PoolPlugin>, Error> {
-        let pool = self.inner.lock().unwrap();
-        for instance in pool.instances.iter() {
-            if std::rc::Rc::strong_count(&instance.0) == 1 {
-                return Ok(Some(instance.clone()));
-            }
-        }
-        Ok(None)
-    }
-
-    /// Get the number of live instances for a plugin
+    /// Get the number of live instances for a plugin (both checked out and available)
     pub fn count(&self) -> usize {
-        self.inner.lock().unwrap().instances.len()
+        self.inner.lock().unwrap().current_size
     }
 
     /// Get access to a plugin, this will create a new instance if needed (and allowed by the specified
@@ -130,66 +98,161 @@ impl Pool {
     /// acquired
     pub fn get(&self, timeout: std::time::Duration) -> Result<Option<PoolPlugin>, Error> {
         let start = std::time::Instant::now();
-        let max = self.config.max_instances;
-        if let Some(avail) = self.find_available()? {
-            return Ok(Some(avail));
-        }
 
-        {
-            let mut pool = self.inner.lock().unwrap();
-            if pool.instances.len() < max {
-                let plugin = (*pool.plugin_source)()?;
-                let instance = PoolPlugin::new(plugin);
-                pool.instances.push(instance);
-                return Ok(Some(pool.instances.last().unwrap().clone()));
-            }
-        }
+        let mut inner = self.inner.lock().unwrap();
 
         loop {
-            if let Ok(Some(x)) = self.find_available() {
-                return Ok(Some(x));
+            // Try to get an available plugin
+            if let Some(plugin) = inner.available.pop_front() {
+                return Ok(Some(PoolPlugin {
+                    plugin: Some(plugin),
+                    pool: Arc::downgrade(&self.inner),
+                    cond: self.cond.clone(),
+                }));
             }
-            if std::time::Instant::now() - start > timeout {
+
+            // Try to create a new plugin if under max
+            if inner.current_size < inner.max_size {
+                let plugin = (*inner.plugin_source)()?;
+                inner.current_size += 1;
+                return Ok(Some(PoolPlugin {
+                    plugin: Some(plugin),
+                    pool: Arc::downgrade(&self.inner),
+                    cond: self.cond.clone(),
+                }));
+            }
+
+            // Check timeout
+            let elapsed = std::time::Instant::now() - start;
+            if elapsed >= timeout {
                 return Ok(None);
             }
 
-            std::thread::sleep(std::time::Duration::from_millis(100));
+            // Wait for a plugin to be returned
+            let remaining = timeout - elapsed;
+            let (guard, wait_result) = self.cond.wait_timeout(inner, remaining).unwrap();
+            inner = guard;
+
+            if wait_result.timed_out() {
+                return Ok(None);
+            }
         }
     }
 
-    /// Access a plugin in a callback function. This calls `Pool::get` then the provided
-    /// callback. `Ok(None)` is returned if the timeout is reached before an available
-    /// plugin could be acquired
+    /// Access a plugin in a callback function. This calls `Pool::get` then the provided callback. `Ok(None)`
+    /// is returned if the timeout is reached before an available plugin could be acquired
     pub fn with_plugin<T>(
         &self,
         timeout: std::time::Duration,
         f: impl FnOnce(&mut Plugin) -> Result<T, Error>,
     ) -> Result<Option<T>, Error> {
-        if let Some(plugin) = self.get(timeout)? {
-            return f(&mut plugin.plugin()).map(Some);
+        if let Some(mut plugin) = self.get(timeout)? {
+            return f(&mut plugin).map(Some);
         }
         Ok(None)
     }
 
-    /// Returns `true` if the given function exists, otherwise `false`. Results are cached
-    /// after the first call.
+    /// Returns `true` if the given function exists, otherwise `false`. Results are cached after the first
+    /// call.
     pub fn function_exists(&self, name: &str, timeout: std::time::Duration) -> Result<bool, Error> {
         // read current value if any
         let read = self.existing_functions.read().unwrap();
         let exists_opt = read.get(name).cloned();
         drop(read);
+
         if let Some(exists) = exists_opt {
             Ok(exists)
         } else {
             // load plugin and call function_exists
             let plugin = self.get(timeout)?;
-            let exists = plugin.unwrap().0.borrow().function_exists(name);
+            if let Some(p) = plugin.as_ref() {
+                let exists = p.plugin.as_ref().unwrap().function_exists(name);
 
-            // write result to hashmap
-            let mut write = self.existing_functions.write().unwrap();
-            write.insert(name.to_string(), exists);
+                // write result to hashmap
+                let mut write = self.existing_functions.write().unwrap();
+                write.insert(name.to_string(), exists);
 
-            Ok(exists)
+                Ok(exists)
+            } else {
+                // Timeout - return false but don't cache, since we don't
+                // actually know whether the function exists
+                Ok(false)
+            }
+        }
+    }
+}
+
+/// `PoolPlugin` wraps a plugin checked out from a pool. When dropped, the plugin is automatically returned
+/// to the pool.
+pub struct PoolPlugin {
+    /// The checked-out plugin. Wrapped in `Option` so it can be moved out on drop.
+    plugin: Option<Plugin>,
+    /// Weak reference to the pool, used to return the plugin on drop. Using `Weak` allows the pool
+    /// to be fully dropped even if plugins are still checked out; when those plugins are dropped,
+    /// they'll see the pool is gone and simply drop themselves.
+    pool: Weak<Mutex<PoolInner>>,
+    /// Condition variable to notify waiters when this plugin is returned.
+    cond: Arc<Condvar>,
+}
+
+impl std::fmt::Debug for PoolPlugin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PoolPlugin")
+            .field("plugin", &self.plugin.as_ref().map(|p| p.id))
+            .finish()
+    }
+}
+
+impl PoolPlugin {
+    /// Helper to call a plugin function on the underlying plugin
+    pub fn call<'a, Input: ToBytes<'a>, Output: FromBytesOwned>(
+        &mut self,
+        name: impl AsRef<str>,
+        input: Input,
+    ) -> Result<Output, Error> {
+        self.plugin
+            .as_mut()
+            .expect("plugin is Some until Drop runs")
+            .call(name.as_ref(), input)
+    }
+
+    /// Helper to get the underlying plugin's ID
+    pub fn id(&self) -> uuid::Uuid {
+        self.plugin
+            .as_ref()
+            .expect("plugin is Some until Drop runs")
+            .id
+    }
+}
+
+impl std::ops::Deref for PoolPlugin {
+    type Target = Plugin;
+
+    fn deref(&self) -> &Self::Target {
+        self.plugin
+            .as_ref()
+            .expect("plugin is Some until Drop runs")
+    }
+}
+
+impl std::ops::DerefMut for PoolPlugin {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.plugin
+            .as_mut()
+            .expect("plugin is Some until Drop runs")
+    }
+}
+
+impl Drop for PoolPlugin {
+    fn drop(&mut self) {
+        if let Some(plugin) = self.plugin.take() {
+            if let Some(inner) = self.pool.upgrade() {
+                let mut guard = inner.lock().unwrap();
+                guard.available.push_back(plugin);
+                drop(guard);
+                self.cond.notify_one();
+            }
+            // If pool is gone, just drop the plugin
         }
     }
 }

--- a/runtime/src/tests/pool.rs
+++ b/runtime/src/tests/pool.rs
@@ -16,12 +16,13 @@ fn run_thread(p: Pool, i: u64) -> std::thread::JoinHandle<()> {
 
 fn init(max_instances: usize) -> Pool {
     let data = include_bytes!("../../../wasm/code.wasm");
-    let plugin_builder =
-        extism::PluginBuilder::new(extism::Manifest::new([extism::Wasm::data(data)]))
-            .with_wasi(true);
     PoolBuilder::new()
         .with_max_instances(max_instances)
-        .build(move || plugin_builder.clone().build())
+        .build(move || {
+            extism::PluginBuilder::new(extism::Manifest::new([extism::Wasm::data(data)]))
+                .with_wasi(true)
+                .build()
+        })
 }
 
 #[test]
@@ -60,4 +61,36 @@ fn test_exists() -> Result<(), Error> {
     assert!(!pool.function_exists("not_existing", timeout)?);
     assert!(!pool.function_exists("not_existing", timeout)?);
     Ok(())
+}
+
+#[test]
+fn test_pool_with_captured_builder() {
+    let data = include_bytes!("../../../wasm/code.wasm");
+
+    // Try to capture a pre-built PluginBuilder
+    let builder = PluginBuilder::new(Manifest::new([Wasm::data(data)]))
+        .with_wasi(true)
+        .with_function(
+            "my_func",
+            [ValType::I64],
+            [ValType::I64],
+            UserData::new(String::from("hello")),
+            |_plugin: &mut CurrentPlugin,
+             inputs: &[Val],
+             outputs: &mut [Val],
+             _user_data: UserData<String>| {
+                outputs[0] = inputs[0].clone();
+                Ok(())
+            },
+        );
+
+    let pool = PoolBuilder::new()
+        .with_max_instances(2)
+        .build(move || builder.clone().build());
+
+    let handle = std::thread::spawn(move || {
+        pool.get(Duration::from_secs(1)).unwrap();
+    });
+
+    handle.join().unwrap();
 }


### PR DESCRIPTION
This is an alternative to #892 

The pool implementation had an unsound `unsafe impl Sync` on `PoolInner` containing `Vec<PoolPlugin>` where `PoolPlugin` was `Rc<RefCell<Plugin>>`. This caused intermittent "RefCell already borrowed" panics in multi-threaded usage (issue #891).

The problem with the original design was that it assumed external locking (the pool's `Mutex`) would be sufficient to make `Rc<RefCell<>>` safe to share across threads. However, there were several issues that made the design unsound:

1. `PoolPlugin` had no `Drop` implementation to synchronize refcount decrements. When dropped on different threads, unsynchronized `Rc` refcount modifications could lead to data races.
2. The pool used `Rc::strong_count == 1` to track availability, but had no control over when clones were created or destroyed. Callers could clone and keep `PoolPlugin` instances, breaking the availability tracking.
3. The `PoolPlugin` type didn't leverage the type system to enforce safe usage patterns; it relied entirely on external locking that the type system couldn't verify.

This replaces the unsafe implementation with proper thread-safe primitives and move semantics inspired by the deadpool crate.

Changes:

- Replace shared `Rc<RefCell<Plugin>>` with move semantics: plugins are moved out of a `VecDeque` when checked out and moved back on drop
- `PoolPlugin` now owns the plugin and implements `Drop` to automatically return it, making checkout/return atomic and type-safe
- Add `unsafe impl Send/Sync` for `UserDataHandle` to complete the chain of unsafe assertions. This trusts that the existing `unsafe impl<T> Send for UserData<T>` is sound (verified: `UserData::get()` only returns `Arc<Mutex<T>>`, never extracts `T`, so it cannot be moved across threads unsafely)
- Replace busy-wait polling with `Condvar` for efficient waiting
- `PoolPlugin` implements `Deref`/`DerefMut` for ergonomic access
- Use `Weak` reference to pool so checked-out plugins don't keep pool alive
- Fix `function_exists` to handle timeout gracefully instead of panicking
- Add test for pools with captured `PluginBuilder` containing custom functions

Breaking API changes:

- `PoolPlugin` no longer has a `.plugin()` method - it now implements
  `Deref`/`DerefMut`, so you can use it directly where you previously
  called `.plugin()`. Example: `pool.get()?.call(...)` instead of
  `pool.get()?.plugin().call(...)`
- `PoolPlugin::call()` now takes `&mut self` instead of `&self` (direct
  ownership instead of interior mutability via `RefCell`)

Fixes #891
