### PR TITLE
agent: add Claude Code rules for runtime confusion areas

### DIFF
--- a/.claude/rules/runtime/src/c-sdk-ffi-safety.md
+++ b/.claude/rules/runtime/src/c-sdk-ffi-safety.md
@@ -1,0 +1,27 @@
+---
+paths:
+  - 'runtime/src/sdk.rs'
+  - 'runtime/extism.h'
+---
+
+# C SDK FFI Safety Principles
+
+These patterns have all been learned from real bugs across the FFI boundary:
+
+### 1. Never Panic Across FFI (commit 4db57de)
+All fallible operations must use `Result` handling and return null/error codes. Panics crossing into C are UB. Use `.unwrap_or_else()` with error output params, not `.unwrap()`.
+
+### 2. Null-Terminate All Error Strings (commit 6d2735c)
+C consumers have no way to get error message length. The `make_error_msg()` helper appends `\0`. Always use it when storing error messages.
+
+### 3. Empty Vec = Null Pointer (commit 34096bd)
+`Vec::as_ptr()` returns a dangling pointer when the vec is empty. FFI consumers (especially JNA) will dereference it and SIGSEGV. Always check `is_empty()` and return `null` for empty vecs.
+
+### 4. Float Bit Conversion (commit 7775c57)
+When converting `ExtismVal` floats to wasmtime `Val`, use `f32::to_bits()` / `f64::to_bits()`, not `as` casts. Wasmtime `Val::F32`/`Val::F64` expect bit representations.
+
+### 5. ExtismFunction is Single-Use
+`ExtismFunction` wraps `Cell<Option<Function>>`. Calling `.take()` consumes it. A function pointer can only be registered with one plugin. Passing a consumed pointer to a second plugin returns an error.
+
+### 6. CString Ownership for Error Output Params
+Error output params (`char **errmsg`) use `CString::into_raw()` to transfer ownership to C. The caller must free with `extism_plugin_new_error_free()`. Always check `!errmsg.is_null()` before writing.

--- a/.claude/rules/runtime/src/current-plugin-raw-pointers.md
+++ b/.claude/rules/runtime/src/current-plugin-raw-pointers.md
@@ -1,0 +1,23 @@
+---
+paths:
+  - 'runtime/src/current_plugin.rs'
+  - 'runtime/src/plugin.rs'
+---
+
+# CurrentPlugin Raw Pointer Invariants
+
+`CurrentPlugin` holds raw `*mut` pointers to `Store` and `Linker` because wasmtime's `Store<CurrentPlugin>` owns `CurrentPlugin` as its data, creating a circular dependency. Host functions receive `Caller<CurrentPlugin>` (giving `&mut CurrentPlugin`) but need access to the `Store`/`Linker` for memory operations. Raw pointers are the only way to provide this back-reference.
+
+### Critical Invariant: Pointer Re-synchronization
+
+These raw pointers **must be re-set** whenever `Store` or `Linker` are recreated:
+
+- After `Plugin::new_from_compiled` (lines ~431-432)
+- After `reset_store` (lines ~477-481)
+- Before `set_input` (lines ~567-571, defensive re-sync)
+
+Forgetting to re-sync after store recreation produces dangling pointer bugs. Commit ecf18a2 fixed exactly this in `reset_store`.
+
+### Safety Guarantees
+
+Pointers are safe because they're only dereferenced during synchronous host function calls where the `Plugin` struct is on the stack and cannot move. The `Store`/`Linker` fields don't relocate within a `Plugin`'s lifetime.

--- a/.claude/rules/runtime/src/pdk-memory-ownership.md
+++ b/.claude/rules/runtime/src/pdk-memory-ownership.md
@@ -1,0 +1,25 @@
+---
+paths:
+  - 'runtime/src/pdk.rs'
+  - 'runtime/src/current_plugin.rs'
+---
+
+# PDK Host Function Memory Ownership
+
+### Rule: Host functions own all input memory handles
+
+Every PDK function that receives a memory handle offset **must call `memory_free()` on it**. The host takes ownership; the plugin (caller) must not free it.
+
+This was formalized in commit 3ac3d9a. All current PDK functions follow this pattern consistently:
+- `config_get`, `var_get`: free key handle, allocate and return new handle for value
+- `var_set`: frees both key and value handles
+- `http_request`: frees request handle; frees body handle only if offset > 0
+- `log_*` functions: all delegate to `log()` which frees the message handle
+
+### Rule: Return values are new allocations
+
+Functions that return data allocate new memory with `memory_new()` and pass ownership to the caller (plugin). The plugin is then responsible for freeing returned handles.
+
+### ExternRef Single-Allocation Pattern
+
+`Plugin` pre-allocates one `ExternRef` at creation (in `relink()`) and reuses it across calls by swapping the inner `Box<dyn Any>` value in `raw_call`. This avoids wasmtime's "failed to allocate externref" error (commit d2a3699). The ExternRef is reset to `Box::new(())` after each call.

--- a/.claude/rules/runtime/src/plugin-call-lifecycle.md
+++ b/.claude/rules/runtime/src/plugin-call-lifecycle.md
@@ -1,0 +1,28 @@
+---
+paths:
+  - 'runtime/src/plugin.rs'
+  - 'runtime/src/lib.rs'
+---
+
+# Plugin Call Lifecycle and Error Handling
+
+### Call Flow in `raw_call`
+
+1. Reset fuel if configured
+2. `reset_store` if flagged (WASI command module ran `_start` last time)
+3. `instantiate` lazily (only if instance is None, detects guest runtime)
+4. Swap host context into pre-allocated ExternRef
+5. `set_input` (re-syncs raw pointers, resets kernel memory, writes input)
+6. Start timer with epoch interruption
+7. Call the function
+8. Reset host context to `()`
+9. Stop timer, set `store_needs_reset` if function was `_start`
+10. Handle errors (fuel, extism error, wasmtime trap, WASI exit, OOM, timeout)
+
+### Fuel Detection Gotcha (commit c2866a7)
+
+The `catch_out_of_fuel!` macro checks `store.get_fuel().is_ok_and(|x| x == 0)` after an error. You can't rely on the error type alone to detect out-of-fuel; you must check the remaining fuel value. This macro is used throughout `plugin.rs` and `lib.rs`.
+
+### Instantiation Tracking
+
+The `instantiations` counter tracks how many times the module has been instantiated. Wasmtime `Instance`s are only cleaned up when their `Store` is dropped, so repeated instantiations without store resets can cause memory buildup. The counter is reset to 0 when `reset_store()` runs.

--- a/.claude/rules/runtime/src/wasi-command-vs-reactor.md
+++ b/.claude/rules/runtime/src/wasi-command-vs-reactor.md
@@ -1,0 +1,23 @@
+---
+paths:
+  - 'runtime/src/plugin.rs'
+  - 'runtime/src/internal.rs'
+  - 'runtime/Cargo.toml'
+---
+
+# WASI: Command vs Reactor Modules and wasi-common
+
+### Command Modules (`_start`) Require Full Store Reset
+
+Per the WASI spec, `_start` should be called "at most once." When a plugin calls `_start`, `store_needs_reset` is set to `true` (line ~890). On the next call, `reset_store()` recreates the entire `Store`, `Linker`, WASI context, and re-links all host functions. This is expensive but necessary because command modules may corrupt global state.
+
+- **Reactor modules** (`_initialize` / `__wasm_call_ctors`): Initialize once, stay alive across multiple calls. No store reset needed.
+- **Haskell modules**: Detected by `hs_init` export; may also have `_initialize` as reactor.
+
+### Why `wasi-common` Instead of `wasmtime-wasi`
+
+The project uses `wasi-common` (not `wasmtime-wasi`) to avoid tokio async runtime conflicts (see wasmtime issue #8799, commit 9dbc228). The runtime is fully synchronous. Both `wasi-common` and `wasmtime` version ranges must stay synchronized (currently 26.x).
+
+### Error Handling for WASI Exits
+
+WASI command modules exit via `wasi_common::I32Exit`. The `raw_call` function handles this specially: exit code 0 without an Extism error is treated as success; non-zero exit codes and exit code 0 with Extism errors are returned as errors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# Project
+
+## Continuous Documentation
+
+As you work, think about any information that might be helpful to know in future work sessions without the user re-providing the information.
+
+This might include
+
+- High-level architecture for complex areas of the codebase (if not obvious)
+- Specific commands that are recommended
+- Debugging strategies for complex areas of the codebase (if not obvious)
+- Anything confusing that is encountered in the work session
+
+### Documenting Confusion / Mistakes
+
+It is very important to document any tribal knowledge, complex architectural decisions, and any confusion or mistakes you encounter in Claude Rules (`.claude/rules`).
+Please see `.codeyam/rules/instructions.md` for guidance.


### PR DESCRIPTION
Add rules documenting non-obvious patterns learned from commit history: raw pointer invariants, PDK memory ownership, WASI command vs reactor modules, C SDK FFI safety, and plugin call lifecycle.