### PR TITLE
Add Plugin::memory_status() to query memory limiter state

### DIFF
--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -24,8 +24,17 @@ pub struct CurrentPlugin {
 unsafe impl Send for CurrentPlugin {}
 
 pub(crate) struct MemoryLimiter {
-    bytes_left: usize,
-    max_bytes: usize,
+    pub(crate) bytes_left: usize,
+    pub(crate) max_bytes: usize,
+}
+
+/// Reports the current memory limiter state of a plugin.
+#[derive(Clone, Copy, Debug)]
+pub struct MemoryStatus {
+    /// Remaining allocatable bytes.
+    pub bytes_left: usize,
+    /// Configured maximum bytes.
+    pub max_bytes: usize,
 }
 
 impl MemoryLimiter {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -36,7 +36,7 @@ mod timer;
 /// Extism C API
 pub mod sdk;
 
-pub use current_plugin::CurrentPlugin;
+pub use current_plugin::{CurrentPlugin, MemoryStatus};
 pub use extism_convert::{FromBytes, FromBytesOwned, ToBytes};
 pub use extism_manifest::{Manifest, Wasm, WasmMetadata};
 pub use function::{Function, UserData, Val, ValType, PTR};

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -1230,6 +1230,15 @@ impl Plugin {
             )
         })
     }
+
+    /// Returns the current memory limiter status, or `None` if no memory
+    /// limit was configured (i.e., `available_pages` was `None` in the manifest).
+    pub fn memory_status(&self) -> Option<MemoryStatus> {
+        self.store.data().memory_limiter.as_ref().map(|limiter| MemoryStatus {
+            bytes_left: limiter.bytes_left,
+            max_bytes: limiter.max_bytes,
+        })
+    }
 }
 
 // Enumerates the PDK languages that need some additional initialization

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -1234,10 +1234,14 @@ impl Plugin {
     /// Returns the current memory limiter status, or `None` if no memory
     /// limit was configured (i.e., `available_pages` was `None` in the manifest).
     pub fn memory_status(&self) -> Option<MemoryStatus> {
-        self.store.data().memory_limiter.as_ref().map(|limiter| MemoryStatus {
-            bytes_left: limiter.bytes_left,
-            max_bytes: limiter.max_bytes,
-        })
+        self.store
+            .data()
+            .memory_limiter
+            .as_ref()
+            .map(|limiter| MemoryStatus {
+                bytes_left: limiter.bytes_left,
+                max_bytes: limiter.max_bytes,
+            })
     }
 }
 

--- a/runtime/src/tests/memory_status.rs
+++ b/runtime/src/tests/memory_status.rs
@@ -1,0 +1,39 @@
+use crate::*;
+
+const WASM: &[u8] = include_bytes!("../../../wasm/code.wasm");
+
+#[test]
+fn memory_status_none_without_limiter() {
+    let plugin = Plugin::new(WASM, [], true).unwrap();
+    assert!(plugin.memory_status().is_none());
+}
+
+#[test]
+fn memory_status_some_with_limiter() {
+    let manifest =
+        extism_manifest::Manifest::new([extism_manifest::Wasm::data(WASM)]).with_memory_max(2);
+    let plugin = Plugin::new(&manifest, [], true).unwrap();
+    let status = plugin.memory_status().expect("should be Some");
+    assert_eq!(status.max_bytes, 2 * 65536);
+    assert_eq!(status.bytes_left, status.max_bytes);
+}
+
+#[test]
+fn memory_status_clone_copy_debug() {
+    let status = MemoryStatus {
+        bytes_left: 1024,
+        max_bytes: 2048,
+    };
+    // Test Copy
+    let copied = status;
+    assert_eq!(copied.bytes_left, status.bytes_left);
+    assert_eq!(copied.max_bytes, status.max_bytes);
+    // Test Clone
+    let cloned = status.clone();
+    assert_eq!(cloned.bytes_left, status.bytes_left);
+    assert_eq!(cloned.max_bytes, status.max_bytes);
+    // Test Debug
+    let debug_str = format!("{:?}", status);
+    assert!(debug_str.contains("1024"));
+    assert!(debug_str.contains("2048"));
+}

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod issues;
 mod kernel;
+mod memory_status;
 mod pool;
 mod runtime;


### PR DESCRIPTION
Add a public memory_status method to Plugin that returns the current memory limiter values (bytes_left and max_bytes), following the same read-only query pattern as fuel_consumed. Returns None when no memory limit is configured.

- Add MemoryStatus struct with Clone, Copy, Debug derives
- Make MemoryLimiter fields pub(crate) for internal access
- Re-export MemoryStatus from crate root
- Add unit tests for None/Some cases and trait derivations