### PR TITLE
Upgrade wasmtime to v43

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-wasmtime = { version = "41", default-features = false, features = [
+wasmtime = { version = "43", default-features = false, features = [
   'cache',
   'gc',
   'gc-drc',
@@ -20,8 +20,8 @@ wasmtime = { version = "41", default-features = false, features = [
   'pooling-allocator',
   'demangle',
 ] }
-wasi-common = "41"
-wiggle = "41"
+wasi-common = "43"
+wiggle = "43"
 anyhow = "1"
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use wasmtime::error::Context as _;
 
 use crate::*;
 
@@ -43,13 +43,13 @@ impl wasmtime::ResourceLimiter for MemoryLimiter {
     ) -> Result<bool> {
         if let Some(max) = maximum {
             if desired >= max {
-                return Err(Error::msg("oom"));
+                return Err(wasmtime::Error::msg("oom"));
             }
         }
 
         let d = desired - current;
         if d > self.bytes_left {
-            return Err(Error::msg("oom"));
+            return Err(wasmtime::Error::msg("oom"));
         }
 
         self.bytes_left -= d;

--- a/runtime/src/function.rs
+++ b/runtime/src/function.rs
@@ -166,7 +166,7 @@ unsafe impl<T> Sync for UserData<T> {}
 unsafe impl Send for CPtr {}
 unsafe impl Sync for CPtr {}
 
-type FunctionInner = dyn Fn(wasmtime::Caller<CurrentPlugin>, &[wasmtime::Val], &mut [wasmtime::Val]) -> Result<(), Error>
+pub(crate) type FunctionInner = dyn Fn(wasmtime::Caller<CurrentPlugin>, &[wasmtime::Val], &mut [wasmtime::Val]) -> Result<(), Error>
     + Sync
     + Send;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -5,7 +5,7 @@ macro_rules! catch_out_of_fuel {
     ($store: expr, $x:expr) => {{
         let y = $x;
         if y.is_err() && $store.get_fuel().is_ok_and(|x| x == 0) {
-            Err(Error::msg("plugin ran out of fuel"))
+            Err(wasmtime::Error::msg("plugin ran out of fuel"))
         } else {
             y
         }

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -5,8 +5,8 @@ use std::{
     sync::TryLockError,
 };
 
-use anyhow::Context;
 use plugin_builder::PluginBuilderOptions;
+use wasmtime::error::Context as _;
 
 use crate::*;
 
@@ -53,7 +53,6 @@ impl CompiledPlugin {
     pub fn new(builder: PluginBuilder) -> Result<CompiledPlugin, Error> {
         let mut config = builder.config.unwrap_or_default();
         config
-            .async_support(false)
             .epoch_interruption(true)
             .debug_info(builder.options.debug_options.debug_info)
             .coredump_on_trap(builder.options.debug_options.coredump.is_some())
@@ -329,11 +328,14 @@ fn relink(
     linker.allow_shadowing(true);
 
     // Define PDK functions
+    use wasmtime::error::ToWasmtimeResult as _;
     macro_rules! add_funcs {
             ($($name:ident($($args:expr),*) $(-> $($r:expr),*)?);* $(;)?) => {
                 $(
                     let t = FuncType::new(&engine, [$($args),*], [$($($r),*)?]);
-                    linker.func_new(EXTISM_ENV_MODULE, stringify!($name), t, pdk::$name)?;
+                    linker.func_new(EXTISM_ENV_MODULE, stringify!($name), t, |c, i, o| {
+                        pdk::$name(c, i, o).to_wasmtime_result()
+                    })?;
                 )*
             };
         }
@@ -401,7 +403,10 @@ fn relink(
         let name = f.name();
         let ns = f.namespace().unwrap_or(EXTISM_USER_MODULE);
         unsafe {
-            linker.func_new(ns, name, f.ty(engine).clone(), &*(f.f.as_ref() as *const _))?;
+            let func: &'static function::FunctionInner = &*(f.f.as_ref() as *const _);
+            linker.func_new(ns, name, f.ty(engine).clone(), move |c, i, o| {
+                func(c, i, o).to_wasmtime_result()
+            })?;
         }
     }
 
@@ -877,10 +882,14 @@ impl Plugin {
         let input = input.as_ref();
 
         if let Some(fuel) = self.fuel {
-            self.store.set_fuel(fuel).map_err(|x| (x, -1))?;
+            self.store.set_fuel(fuel).map_err(|x| (x.into(), -1))?;
         }
 
-        catch_out_of_fuel!(&self.store, self.reset_store(lock)).map_err(|x| (x, -1))?;
+        catch_out_of_fuel!(
+            &self.store,
+            self.reset_store(lock).map_err(wasmtime::Error::from_anyhow)
+        )
+        .map_err(|x| (x.into(), -1))?;
 
         self.instantiate(lock).map_err(|e| (e, -1))?;
 
@@ -889,7 +898,7 @@ impl Plugin {
             if let Some(inner) = self
                 .host_context
                 .data_mut(&mut self.store)
-                .map_err(|x| (x, -1))?
+                .map_err(|x| (x.into(), -1))?
             {
                 if let Some(inner) = inner.downcast_mut::<Box<dyn std::any::Any + Send + Sync>>() {
                     let x: Box<T> = Box::new(host_context);
@@ -957,7 +966,7 @@ impl Plugin {
 
         let mut rc = -1;
         if self.store.get_fuel().is_ok_and(|x| x == 0) {
-            res = Err(Error::msg("plugin ran out of fuel"));
+            res = Err(wasmtime::Error::msg("plugin ran out of fuel"));
         } else {
             // Get extism error
             let output_res = self.get_output_after_call().map_err(|x| (x, -1));
@@ -985,13 +994,13 @@ impl Plugin {
                             "call to {name} returned with error message: {}", x
                         );
                         if let Err(e) = res {
-                            res = Err(Error::msg(x).context(e));
+                            res = Err(wasmtime::Error::msg(x).context(e));
                         } else {
-                            res = Err(Error::msg(x))
+                            res = Err(wasmtime::Error::msg(x))
                         }
                     }
                     Err(msg) => {
-                        res = Err(Error::msg(format!(
+                        res = Err(wasmtime::Error::msg(format!(
                             "unable to load error message from memory: {msg}",
                         )));
                     }
@@ -1063,7 +1072,7 @@ impl Plugin {
                         return Ok(0);
                     }
 
-                    return Err((e, exit_code));
+                    return Err((e.into(), exit_code));
                 }
 
                 // Handle timeout interrupts
@@ -1086,7 +1095,7 @@ impl Plugin {
                     plugin = self.id.to_string(),
                     "call to {name} encountered an error: {e:?}"
                 );
-                Err((e, rc))
+                Err((e.into(), rc))
             }
         }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.90.0"
+channel = "1.91.0"


### PR DESCRIPTION
v43.0.1 patches the [2026-04-09 security advisory cluster][adv] which
includes 41.0.4 in the affected range. Two of these are critical sandbox
escapes:

- [GHSA-jhxm-h53p-jm7w][cvp1] — miscompiled guest heap access on aarch64 Cranelift
- [GHSA-xx5w-cvp6-jv83][cvp2] — sandbox-escaping memory access via the Winch backend

The 41.x line has no patch release for these advisories; the patched lines are
24 (LTS), 36 (LTS), 42 (42.0.2), and 43 (43.0.1).

### Why v43 instead of v42 or v44

- **v42 vs v43**: same MSRV (1.91.0). v43 includes the fix for converting
  `wasmtime::Error` into `anyhow::Error` and using `downcast` ([upstream
  #12689][12689]) — the runtime relies on this for the `Trap`, `I32Exit`,
  and `WasmCoreDump` downcasts in `plugin.rs`.
- **v43 vs v44**: v44 requires Rust 1.92.0; v43 only needs 1.91.0.

### Breaking change handled

v42 stopped re-exporting `anyhow::Error` and introduced `wasmtime::Error`/
`wasmtime::Result`. The runtime still exposes `anyhow::Error` as the public
SDK error type; conversion happens at the wasmtime boundary via
`ToWasmtimeResult` and the `From<wasmtime::Error> for anyhow::Error` impl.

### Changes

- `wasmtime` / `wasi-common` / `wiggle`: 41 → 43
- `rust-toolchain.toml`: 1.90.0 → 1.91.0
- Wrap pdk and user import host functions with `.to_wasmtime_result()` so the
  closures match the new `Linker::func_new` signature.
- `ResourceLimiter` impl and `catch_out_of_fuel!` macro produce `wasmtime::Error`.
- Drop deprecated `Config::async_support(false)` (a no-op since v42).

### Verification

- `cargo build --release -p libextism` ✓
- `cargo build --release --benches -p extism` ✓
- `cargo fmt --check` ✓
- `cargo clippy --all --release --all-features --no-deps -- -D "clippy::all"` ✓
- `cargo test --release` / `--all-features` / `--no-default-features` — 43/44 pass.
  `tests::runtime::test_disable_cache` is a pre-existing timing-based flake
  (passes in isolation, fails under parallel test load); confirmed to also fail
  on `main` before this change.

Release notes: [v42][v42], [v43][v43]

Fixes #898

[adv]: https://bytecodealliance.org/articles/wasmtime-security-advisories
[cvp1]: https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-jhxm-h53p-jm7w
[cvp2]: https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-xx5w-cvp6-jv83
[12689]: https://github.com/bytecodealliance/wasmtime/pull/12689
[v42]: https://github.com/bytecodealliance/wasmtime/releases/tag/v42.0.0
[v43]: https://github.com/bytecodealliance/wasmtime/releases/tag/v43.0.0