### PR TITLE
Remove dependency on wiggle

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -27,8 +27,8 @@ anyhow = "1"
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = "0.9"
-sha2 = "0.10"
+toml = "1"
+sha2 = "0.11"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.23", features = [
   "std",

--- a/runtime/extism.h
+++ b/runtime/extism.h
@@ -104,7 +104,10 @@ typedef void (*ExtismFunctionType)(ExtismCurrentPlugin *plugin,
  */
 typedef void (*ExtismLogDrainFunctionType)(const char *data, ExtismSize size);
 
-
+/**
+ * A wrapper around `ValType::I64` to specify arguments that are pointers to memory blocks
+ */
+#define PTR ExtismValType_I64
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Using the default feature for wiggle leads to witx being pulled in. witx in unmaintained and has some quite old dependencies.

It seems like it is OK to skip this for extism. (As in the only failing test locally, also fails with default features...)

Edit: then wiggle is actually not used explicitly in the code base and I get the same test failure if I remove it...

Edit: second commit removes wiggle completely.

Edit: wiggle (and witx) is still pulled in through wasi-common, but at least it is a bit of a cleanup for extism to get rid of it there...

Suggested to squash the commits. Just kept them for you to select which variant should be there.