### PR TITLE
Upgrade to Wasmtime 46

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,4 @@ updates:
     ignore:
       - dependency-name: "wasmtime"
       - dependency-name: "wasi-common"
-      - dependency-name: "wiggle"
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-wasmtime = { version = "43", default-features = false, features = [
+wasmtime = { version = "46", default-features = false, features = [
   'anyhow',
   'cache',
   'gc',
@@ -21,8 +21,7 @@ wasmtime = { version = "43", default-features = false, features = [
   'pooling-allocator',
   'demangle',
 ] }
-wasi-common = "43"
-wiggle = "43"
+wasi-common = "46"
 anyhow = "1"
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -169,7 +169,7 @@ impl CurrentPlugin {
 
     pub fn memory_bytes_mut(&mut self, handle: MemoryHandle) -> Result<&mut [u8], Error> {
         let (linker, store) = self.linker_and_store();
-        if let Some(mem) = linker.get(&mut *store, EXTISM_ENV_MODULE, "memory") {
+        if let Ok(mem) = linker.get(&mut *store, EXTISM_ENV_MODULE, "memory") {
             let mem = mem.into_memory().unwrap();
             let ptr = unsafe { mem.data_ptr(&*store).add(handle.offset() as usize) };
             if ptr.is_null() {
@@ -183,7 +183,7 @@ impl CurrentPlugin {
 
     pub fn memory_bytes(&mut self, handle: MemoryHandle) -> Result<&[u8], Error> {
         let (linker, store) = self.linker_and_store();
-        if let Some(mem) = linker.get(&mut *store, EXTISM_ENV_MODULE, "memory") {
+        if let Ok(mem) = linker.get(&mut *store, EXTISM_ENV_MODULE, "memory") {
             let mem = mem.into_memory().unwrap();
             let ptr = unsafe { mem.data_ptr(&*store).add(handle.offset() as usize) };
             if ptr.is_null() {
@@ -197,7 +197,7 @@ impl CurrentPlugin {
 
     pub fn host_context<T: 'static>(&mut self) -> Result<&mut T, Error> {
         let (linker, store) = self.linker_and_store();
-        let Some(Extern::Global(xs)) = linker.get(&mut *store, EXTISM_ENV_MODULE, "extism_context")
+        let Ok(Extern::Global(xs)) = linker.get(&mut *store, EXTISM_ENV_MODULE, "extism_context")
         else {
             anyhow::bail!("unable to locate an extism kernel global: extism_context",)
         };
@@ -226,22 +226,24 @@ impl CurrentPlugin {
                 length: 0,
             });
         }
+        let id = self.id;
         let (linker, mut store) = self.linker_and_store();
         let output = &mut [Val::I64(0)];
-        if let Some(f) = linker.get(&mut store, EXTISM_ENV_MODULE, "alloc") {
-            catch_out_of_fuel!(
-                &store,
-                f.into_func()
-                    .unwrap()
-                    .call(&mut *store, &[Val::I64(n as i64)], output)
-                    .context("failed to allocate extism memory")
-            )?;
-        } else {
-            anyhow::bail!("{} unable to allocate memory", self.id);
-        }
+
+        let f = linker
+            .get(&mut store, EXTISM_ENV_MODULE, "alloc")
+            .with_context(|| format!("{} unable to allocate memory", id))?;
+        catch_out_of_fuel!(
+            &store,
+            f.into_func()
+                .unwrap()
+                .call(&mut *store, &[Val::I64(n as i64)], output)
+                .context("failed to allocate extism memory")
+        )?;
+
         let offs = output[0].unwrap_i64() as u64;
         if offs == 0 {
-            anyhow::bail!("{} out of memory", self.id)
+            anyhow::bail!("{} out of memory", id)
         }
         trace!(
             plugin = self.id.to_string(),
@@ -258,34 +260,36 @@ impl CurrentPlugin {
     /// Free a block of Extism plugin memory
     pub fn memory_free(&mut self, handle: MemoryHandle) -> Result<(), Error> {
         let (linker, store) = self.linker_and_store();
-        if let Some(f) = linker.get(&mut *store, EXTISM_ENV_MODULE, "free") {
-            catch_out_of_fuel!(
-                &store,
-                f.into_func()
-                    .unwrap()
-                    .call(&mut *store, &[Val::I64(handle.offset as i64)], &mut [])
-                    .context("failed to free extism memory")
-            )?;
-        } else {
-            anyhow::bail!("unable to locate an extism kernel function: free",)
-        }
+
+        let f = linker
+            .get(&mut *store, EXTISM_ENV_MODULE, "free")
+            .context("unable to locate an extism kernel function: free")?;
+        catch_out_of_fuel!(
+            &store,
+            f.into_func()
+                .unwrap()
+                .call(&mut *store, &[Val::I64(handle.offset as i64)], &mut [])
+                .context("failed to free extism memory")
+        )?;
+
         Ok(())
     }
 
     pub fn memory_length(&mut self, offs: u64) -> Result<u64, Error> {
         let (linker, store) = self.linker_and_store();
         let output = &mut [Val::I64(0)];
-        if let Some(f) = linker.get(&mut *store, EXTISM_ENV_MODULE, "length") {
-            catch_out_of_fuel!(
-                &store,
-                f.into_func()
-                    .unwrap()
-                    .call(&mut *store, &[Val::I64(offs as i64)], output)
-                    .context("failed to get length of extism memory handle")
-            )?;
-        } else {
-            anyhow::bail!("unable to locate an extism kernel function: length",)
-        }
+
+        let f = linker
+            .get(&mut *store, EXTISM_ENV_MODULE, "length")
+            .context("unable to locate an extism kernel function: length")?;
+        catch_out_of_fuel!(
+            &store,
+            f.into_func()
+                .unwrap()
+                .call(&mut *store, &[Val::I64(offs as i64)], output)
+                .context("failed to get length of extism memory handle")
+        )?;
+
         let len = output[0].unwrap_i64() as u64;
         trace!(
             plugin = self.id.to_string(),
@@ -299,17 +303,18 @@ impl CurrentPlugin {
     pub fn memory_length_unsafe(&mut self, offs: u64) -> Result<u64, Error> {
         let (linker, store) = self.linker_and_store();
         let output = &mut [Val::I64(0)];
-        if let Some(f) = linker.get(&mut *store, EXTISM_ENV_MODULE, "length_unsafe") {
-            catch_out_of_fuel!(
-                &store,
-                f.into_func()
-                    .unwrap()
-                    .call(&mut *store, &[Val::I64(offs as i64)], output)
-                    .context("failed to get length of extism memory using length_unsafe")
-            )?;
-        } else {
-            anyhow::bail!("unable to locate an extism kernel function: length_unsafe",)
-        }
+
+        let f = linker
+            .get(&mut *store, EXTISM_ENV_MODULE, "length_unsafe")
+            .context("unable to locate an extism kernel function: length_unsafe")?;
+        catch_out_of_fuel!(
+            &store,
+            f.into_func()
+                .unwrap()
+                .call(&mut *store, &[Val::I64(offs as i64)], output)
+                .context("failed to get length of extism memory using length_unsafe")
+        )?;
+
         let len = output[0].unwrap_i64() as u64;
         trace!(
             plugin = self.id.to_string(),
@@ -424,7 +429,8 @@ impl CurrentPlugin {
     pub(crate) fn memory(&mut self) -> Option<wasmtime::Memory> {
         let (linker, mut store) = self.linker_and_store();
         linker
-            .get(&mut store, EXTISM_ENV_MODULE, "memory")?
+            .get(&mut store, EXTISM_ENV_MODULE, "memory")
+            .ok()?
             .into_memory()
     }
 
@@ -452,7 +458,7 @@ impl CurrentPlugin {
     pub fn clear_error(&mut self) {
         trace!(plugin = self.id.to_string(), "CurrentPlugin::clear_error");
         let (linker, store) = self.linker_and_store();
-        if let Some(f) = linker.get(&mut *store, EXTISM_ENV_MODULE, "error_set") {
+        if let Ok(f) = linker.get(&mut *store, EXTISM_ENV_MODULE, "error_set") {
             let res = f
                 .into_func()
                 .unwrap()
@@ -486,7 +492,7 @@ impl CurrentPlugin {
         debug!(plugin = self.id.to_string(), "set error: {:?}", s);
         let handle = self.memory_new(s)?;
         let (linker, store) = self.linker_and_store();
-        if let Some(f) = linker.get(&mut *store, EXTISM_ENV_MODULE, "error_set") {
+        if let Ok(f) = linker.get(&mut *store, EXTISM_ENV_MODULE, "error_set") {
             catch_out_of_fuel!(
                 &store,
                 f.into_func()
@@ -503,7 +509,7 @@ impl CurrentPlugin {
     pub(crate) fn get_error_position(&mut self) -> (u64, u64) {
         let (linker, store) = self.linker_and_store();
         let output = &mut [Val::I64(0)];
-        if let Some(f) = linker.get(&mut *store, EXTISM_ENV_MODULE, "error_get") {
+        if let Ok(f) = linker.get(&mut *store, EXTISM_ENV_MODULE, "error_get") {
             if let Err(e) = catch_out_of_fuel!(
                 &store,
                 f.into_func().unwrap().call(&mut *store, &[], output)

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -877,15 +877,12 @@ impl Plugin {
         let name = name.as_ref();
         let input = input.as_ref();
 
-        // Setup (instantiation, input marshalling) consumes fuel; keep it off
-        // the caller's budget. The real limit is armed just before the call.
+        // Setup (reset, instantiation, input marshalling) runs with fuel
+        // metering disabled, so none of it can trap on fuel. The caller's
+        // budget is armed later, just before func.call.
         Self::disable_fuel_metering(&mut self.store, self.fuel).map_err(|x| (x, -1))?;
 
-        catch_out_of_fuel!(
-            &self.store,
-            self.reset_store(lock).map_err(wasmtime::Error::from_anyhow)
-        )
-        .map_err(|x| (x.into(), -1))?;
+        self.reset_store(lock).map_err(|x| (x, -1))?;
 
         self.instantiate(lock).map_err(|e| (e, -1))?;
 

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -369,7 +369,7 @@ fn relink(
                     .is_none()
                 && linker
                     .get(&mut store, EXTISM_ENV_MODULE, import.name())
-                    .is_none()
+                    .is_err()
             {
                 let (kind, ty) = match import.ty() {
                     ExternType::Func(t) => ("function", t.to_string()),
@@ -461,9 +461,9 @@ impl Plugin {
             )?,
         );
         store.set_epoch_deadline(1);
-        if let Some(fuel) = compiled.options.fuel {
-            store.set_fuel(fuel)?;
-        }
+        // `relink` below instantiates the modules, which consumes fuel; keep
+        // that off the caller's budget. The real limit is armed per call.
+        Self::disable_fuel_metering(&mut store, compiled.options.fuel)?;
 
         let imports: Vec<Function> = compiled.options.functions.to_vec();
         let (instance_pre, linker, host_context) = relink(
@@ -526,9 +526,9 @@ impl Plugin {
             );
             self.store.set_epoch_deadline(1);
 
-            if let Some(fuel) = self.fuel {
-                self.store.set_fuel(fuel)?;
-            }
+            // `relink` below re-instantiates the modules, which consumes fuel;
+            // keep that off the caller's budget.
+            Self::disable_fuel_metering(&mut self.store, self.fuel)?;
 
             let (instance_pre, linker, host_context) = relink(
                 &engine,
@@ -643,7 +643,7 @@ impl Plugin {
         self.reset()?;
         let handle = self.current_plugin_mut().memory_new(bytes)?;
 
-        if let Some(f) = self
+        if let Ok(f) = self
             .linker
             .get(&mut self.store, EXTISM_ENV_MODULE, "input_set")
         {
@@ -660,7 +660,7 @@ impl Plugin {
             )?;
         }
 
-        if let Some(Extern::Global(ctxt)) =
+        if let Ok(Extern::Global(ctxt)) =
             self.linker
                 .get(&mut self.store, EXTISM_ENV_MODULE, "extism_context")
         {
@@ -675,7 +675,7 @@ impl Plugin {
     pub fn reset(&mut self) -> Result<(), Error> {
         let id = self.id.to_string();
 
-        if let Some(f) = self.linker.get(&mut self.store, EXTISM_ENV_MODULE, "reset") {
+        if let Ok(f) = self.linker.get(&mut self.store, EXTISM_ENV_MODULE, "reset") {
             catch_out_of_fuel!(
                 &self.store,
                 f.into_func()
@@ -805,34 +805,30 @@ impl Plugin {
         let out = &mut [Val::I64(0)];
         let out_len = &mut [Val::I64(0)];
         let store = &mut self.store;
-        if let Some(f) = self
+
+        let f = self
             .linker
             .get(&mut *store, EXTISM_ENV_MODULE, "output_offset")
-        {
-            catch_out_of_fuel!(
-                &store,
-                f.into_func()
-                    .unwrap()
-                    .call(&mut *store, &[], out)
-                    .context("call to set extism output offset failed")
-            )?;
-        } else {
-            anyhow::bail!("unable to set output")
-        }
-        if let Some(f) = self
+            .context("unable to set output")?;
+        catch_out_of_fuel!(
+            &store,
+            f.into_func()
+                .unwrap()
+                .call(&mut *store, &[], out)
+                .context("call to set extism output offset failed")
+        )?;
+
+        let f = self
             .linker
             .get(&mut *store, EXTISM_ENV_MODULE, "output_length")
-        {
-            catch_out_of_fuel!(
-                &store,
-                f.into_func()
-                    .unwrap()
-                    .call(&mut *store, &[], out_len)
-                    .context("call to set extism output length failed")
-            )?;
-        } else {
-            anyhow::bail!("unable to set output length")
-        }
+            .context("unable to set output length")?;
+        catch_out_of_fuel!(
+            &store,
+            f.into_func()
+                .unwrap()
+                .call(&mut *store, &[], out_len)
+                .context("call to set extism output length failed")
+        )?;
 
         let offs = out[0].unwrap_i64() as u64;
         let len = out_len[0].unwrap_i64() as u64;
@@ -881,9 +877,9 @@ impl Plugin {
         let name = name.as_ref();
         let input = input.as_ref();
 
-        if let Some(fuel) = self.fuel {
-            self.store.set_fuel(fuel).map_err(|x| (x.into(), -1))?;
-        }
+        // Setup (instantiation, input marshalling) consumes fuel; keep it off
+        // the caller's budget. The real limit is armed just before the call.
+        Self::disable_fuel_metering(&mut self.store, self.fuel).map_err(|x| (x, -1))?;
 
         catch_out_of_fuel!(
             &self.store,
@@ -945,6 +941,10 @@ impl Plugin {
         self.store.epoch_deadline_trap();
         self.store.set_epoch_deadline(1);
         self.current_plugin_mut().start_time = std::time::Instant::now();
+
+        // Now that setup is complete, arm the caller's fuel limit so it bounds
+        // execution of the exported function only.
+        Self::apply_fuel_limit(&mut self.store, self.fuel).map_err(|x| (x, -1))?;
 
         // Call the function
         let mut results = vec![wasmtime::Val::I32(0); n_results];
@@ -1208,7 +1208,7 @@ impl Plugin {
         self.error_msg = None;
         let (linker, mut store) = self.linker_and_store();
         #[allow(clippy::needless_borrows_for_generic_args)]
-        if let Some(f) = linker.get(&mut *store, EXTISM_ENV_MODULE, "error_set") {
+        if let Ok(f) = linker.get(&mut *store, EXTISM_ENV_MODULE, "error_set") {
             let x = f
                 .into_func()
                 .unwrap()
@@ -1219,6 +1219,28 @@ impl Plugin {
         } else {
             anyhow::bail!("Plugin::clear_error failed, extism:host/env::error_set not found")
         }
+    }
+
+    /// Grant the store effectively unlimited fuel so SDK setup work (module
+    /// instantiation, kernel calls) is not charged against the caller's budget.
+    /// No-op when fuel limiting is disabled.
+    fn disable_fuel_metering(
+        store: &mut Store<CurrentPlugin>,
+        fuel: Option<u64>,
+    ) -> Result<(), Error> {
+        if fuel.is_some() {
+            store.set_fuel(u64::MAX)?;
+        }
+        Ok(())
+    }
+
+    /// Arm the caller's configured fuel limit, bounding execution of the next
+    /// guest call. No-op when fuel limiting is disabled.
+    fn apply_fuel_limit(store: &mut Store<CurrentPlugin>, fuel: Option<u64>) -> Result<(), Error> {
+        if let Some(fuel) = fuel {
+            store.set_fuel(fuel)?;
+        }
+        Ok(())
     }
 
     /// Returns the amount of fuel consumed by the plugin.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.91.0"
+channel = "1.94.0"


### PR DESCRIPTION
**Why?**

Wasmtime 43 has open CVEs and _is not on the [list of Wasmtime releases that receive backports and security fixes](https://docs.wasmtime.dev/stability-release.html)_

**What is changing**

wasmtime 46 changed several APIs and one behavior relevant to extism:

- Linker::get now returns Result instead of Option; updated all call sites accordingly (Some -> Ok, is_none -> is_err, etc.).

- Module instantiation now consumes fuel (e.g. data/element segment init plus any start/_initialize wasm), where it previously did not. (This behavior was added in https://github.com/bytecodealliance/wasmtime/pull/13487.) A small caller fuel limit would therefore trap during build or the per-call setup phase before the guest ran. The caller's fuel limit is meant to bound plugin execution, not SDK setup, so we grant unlimited fuel for setup (instantiation, store reset, input marshalling) and arm the real limit immediately before invoking the exported function. This preserves the pre-46 fuel semantics and keeps fuel_consumed() accurate. Policy is centralized in two helpers: disable_fuel_metering and apply_fuel_limit. 