### PR TITLE
Share variables across plugin instances.

### DIFF
--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -2,11 +2,16 @@ use wasmtime::error::Context as _;
 
 use crate::*;
 
+/// Plugin variables, shared across every instance created from the same
+/// [`CompiledPlugin`]. Wrapped in an `Arc<Mutex<..>>` so that updates made by
+/// one instance are visible to all others and survive a store reset.
+pub(crate) type Vars = std::sync::Arc<std::sync::Mutex<std::collections::BTreeMap<String, Vec<u8>>>>;
+
 /// CurrentPlugin stores data that is available to the caller in PDK functions, this should
 /// only be accessed from inside a host function
 pub struct CurrentPlugin {
-    /// Plugin variables
-    pub(crate) vars: std::collections::BTreeMap<String, Vec<u8>>,
+    /// Plugin variables, shared across every instance
+    pub(crate) vars: Vars,
 
     /// Extism manifest
     pub(crate) manifest: extism_manifest::Manifest,
@@ -320,14 +325,17 @@ impl CurrentPlugin {
         Ok(len)
     }
 
-    /// Access a plugin's variables
-    pub fn vars(&self) -> &std::collections::BTreeMap<String, Vec<u8>> {
-        &self.vars
+    /// Access a plugin's variables. The variables are shared across every
+    /// instance created from the same [`CompiledPlugin`], so the returned guard
+    /// briefly locks the shared store.
+    pub fn vars(&self) -> std::sync::MutexGuard<'_, std::collections::BTreeMap<String, Vec<u8>>> {
+        self.vars.lock().unwrap()
     }
 
-    /// Mutable access to a plugin's variables
-    pub fn vars_mut(&mut self) -> &mut std::collections::BTreeMap<String, Vec<u8>> {
-        &mut self.vars
+    /// Mutable access to a plugin's variables. The variables are shared across
+    /// every instance created from the same [`CompiledPlugin`].
+    pub fn vars_mut(&mut self) -> std::sync::MutexGuard<'_, std::collections::BTreeMap<String, Vec<u8>>> {
+        self.vars.lock().unwrap()
     }
 
     /// Plugin manifest
@@ -341,6 +349,7 @@ impl CurrentPlugin {
         available_pages: Option<u32>,
         allow_http_response_headers: bool,
         id: uuid::Uuid,
+        vars: Vars,
     ) -> Result<Self, Error> {
         let wasi = if wasi {
             let auth = wasi_common::sync::ambient_authority();
@@ -395,7 +404,7 @@ impl CurrentPlugin {
             wasi,
             manifest,
             http_status: 0,
-            vars: BTreeMap::new(),
+            vars,
             linker: std::ptr::null_mut(),
             store: std::ptr::null_mut(),
             available_pages,

--- a/runtime/src/current_plugin.rs
+++ b/runtime/src/current_plugin.rs
@@ -5,7 +5,8 @@ use crate::*;
 /// Plugin variables, shared across every instance created from the same
 /// [`CompiledPlugin`]. Wrapped in an `Arc<Mutex<..>>` so that updates made by
 /// one instance are visible to all others and survive a store reset.
-pub(crate) type Vars = std::sync::Arc<std::sync::Mutex<std::collections::BTreeMap<String, Vec<u8>>>>;
+pub(crate) type Vars =
+    std::sync::Arc<std::sync::Mutex<std::collections::BTreeMap<String, Vec<u8>>>>;
 
 /// CurrentPlugin stores data that is available to the caller in PDK functions, this should
 /// only be accessed from inside a host function
@@ -334,7 +335,9 @@ impl CurrentPlugin {
 
     /// Mutable access to a plugin's variables. The variables are shared across
     /// every instance created from the same [`CompiledPlugin`].
-    pub fn vars_mut(&mut self) -> std::sync::MutexGuard<'_, std::collections::BTreeMap<String, Vec<u8>>> {
+    pub fn vars_mut(
+        &mut self,
+    ) -> std::sync::MutexGuard<'_, std::collections::BTreeMap<String, Vec<u8>>> {
         self.vars.lock().unwrap()
     }
 

--- a/runtime/src/pdk.rs
+++ b/runtime/src/pdk.rs
@@ -77,15 +77,11 @@ pub(crate) fn var_get(
     let key = unsafe {
         std::str::from_utf8_unchecked(std::slice::from_raw_parts(key.as_ptr(), key.len()))
     };
-    let val = data.vars.get(key);
-    let ptr = val.map(|x| (x.len(), x.as_ptr()));
+    let value = data.vars.lock().unwrap().get(key).cloned();
     data.memory_free(handle)?;
 
-    let mem = match ptr {
-        Some((len, ptr)) => {
-            let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
-            data.memory_new(bytes)?
-        }
+    let mem = match value {
+        Some(bytes) => data.memory_new(&bytes)?,
         None => {
             output[0] = Val::I64(0);
             return Ok(());
@@ -127,7 +123,7 @@ pub(crate) fn var_set(
 
     // Remove if the value offset is 0
     if voffset == 0 {
-        data.vars.remove(key);
+        data.vars.lock().unwrap().remove(key);
         data.memory_free(key_handle)?;
         return Ok(());
     }
@@ -142,7 +138,7 @@ pub(crate) fn var_set(
         + key.len()
         + handle.length as usize;
 
-    for (k, v) in data.vars.iter() {
+    for (k, v) in data.vars.lock().unwrap().iter() {
         size += k.len();
         size += v.len();
         size += std::mem::size_of::<String>() + std::mem::size_of::<Vec<u8>>();
@@ -158,8 +154,8 @@ pub(crate) fn var_set(
     data.memory_free(handle)?;
     data.memory_free(key_handle)?;
 
-    // Insert the value from memory into the `vars` map
-    data.vars.insert(key.to_string(), value);
+    // Insert the value from memory into the shared `vars` map
+    data.vars.lock().unwrap().insert(key.to_string(), value);
 
     Ok(())
 }

--- a/runtime/src/plugin.rs
+++ b/runtime/src/plugin.rs
@@ -46,6 +46,9 @@ pub struct CompiledPlugin {
     pub(crate) modules: BTreeMap<String, Module>,
     pub(crate) options: PluginBuilderOptions,
     pub(crate) engine: wasmtime::Engine,
+    /// Variables shared across every `Plugin` instance created from this
+    /// compiled plugin
+    pub(crate) vars: crate::current_plugin::Vars,
 }
 
 impl CompiledPlugin {
@@ -85,6 +88,7 @@ impl CompiledPlugin {
             modules,
             options: builder.options,
             engine,
+            vars: Default::default(),
         })
     }
 
@@ -458,6 +462,7 @@ impl Plugin {
                 available_pages,
                 compiled.options.http_response_headers,
                 id,
+                compiled.vars.clone(),
             )?,
         );
         store.set_epoch_deadline(1);
@@ -514,6 +519,7 @@ impl Plugin {
             let engine = self.store.engine().clone();
             let internal = self.current_plugin_mut();
             let with_wasi = internal.wasi.is_some();
+            let vars = internal.vars.clone();
             self.store = Store::new(
                 &engine,
                 CurrentPlugin::new(
@@ -522,6 +528,7 @@ impl Plugin {
                     internal.available_pages,
                     internal.http_headers.is_some(),
                     self.id,
+                    vars,
                 )?,
             );
             self.store.set_epoch_deadline(1);

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -733,10 +733,7 @@ fn test_vars_shared_across_instances() {
 
     // ...is visible from every other instance.
     assert_eq!(
-        p2.current_plugin()
-            .vars()
-            .get("key")
-            .map(|v| v.as_slice()),
+        p2.current_plugin().vars().get("key").map(|v| v.as_slice()),
         Some(b"value".as_slice())
     );
 

--- a/runtime/src/tests/runtime.rs
+++ b/runtime/src/tests/runtime.rs
@@ -719,6 +719,33 @@ fn test_no_vars() {
 }
 
 #[test]
+fn test_vars_shared_across_instances() {
+    // Every `Plugin` created from the same `CompiledPlugin` should share a
+    // single set of vars.
+    let compiled = CompiledPlugin::new(PluginBuilder::new(WASM_NO_FUNCTIONS)).unwrap();
+    let mut p1 = Plugin::new_from_compiled(&compiled).unwrap();
+    let mut p2 = Plugin::new_from_compiled(&compiled).unwrap();
+
+    // A var set on one instance...
+    p1.current_plugin_mut()
+        .vars_mut()
+        .insert("key".to_string(), b"value".to_vec());
+
+    // ...is visible from every other instance.
+    assert_eq!(
+        p2.current_plugin()
+            .vars()
+            .get("key")
+            .map(|v| v.as_slice()),
+        Some(b"value".as_slice())
+    );
+
+    // Removing it from one instance removes it everywhere.
+    p2.current_plugin_mut().vars_mut().remove("key");
+    assert!(p1.current_plugin().vars().get("key").is_none());
+}
+
+#[test]
 fn test_linking() {
     let manifest = Manifest::new([
         Wasm::Data {


### PR DESCRIPTION
@nilslice 

I was testing a pooled plugin system here: https://github.com/moonrepo/proto/pull/1043

And noticed that vars (via `var::`) are not shared across plugin instances. This kind of feels like an oversight, so thought I would take a stab at fixing it.