### PR TITLE
fix(ci): publish extism_sys wheels after the build finishes

### DIFF
--- a/.github/workflows/release-python.yaml
+++ b/.github/workflows/release-python.yaml
@@ -1,8 +1,7 @@
 name: Release Python SDK
 
 on:
-  release:
-    types: [published, edited]
+  workflow_call:
 
 jobs:
   release-sdks:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,3 +227,9 @@ jobs:
             *.txt
             *.whl
         if: github.ref == 'refs/heads/main'
+
+  release-python:
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: ./.github/workflows/release-python.yaml
+    secrets: inherit


### PR DESCRIPTION
Hey @nilslice and team, thanks for an excellent project!

Debugging an issue in our CI I noticed there are quite a few missing wheels in pypi across many releases/architectures of **extism_sys**.

It appears there is a race condition between `release.yml` and `release-python.yaml`. `release-python.yaml` is triggered as soon as the GitHub release is created, but before all wheels have been built and uploaded to the GitHub release. Only those wheels that have been built and uploaded to the GitHub release by the time `release-python.yaml` hits the pypi upload step land successfully.

The minimal fix here is to trigger `release-python.yaml` only upon successful completion of `release.yml`.

Resolves https://github.com/extism/extism/issues/885.
